### PR TITLE
Fix deleting a naming instance causes "Provider configuration not present" errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,9 @@
-required_providers {
-  random = {
-    source  = "hashicorp/random"
-    version = "~> 2.2"
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2"
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,8 @@
-provider "random" {
-  version = "~> 2.2"
+required_providers {
+  random = {
+    source  = "hashicorp/random"
+    version = "~> 2.2"
+  }
 }
 
 resource "random_string" "main" {


### PR DESCRIPTION
Fix the bug where deleting a naming instance in a parent module causes "Provider configuration not present" errors.

The code as it stood breaks parent modules when they remove references to a naming module instance and violates the Hashicorp guidlines of "Do not explicitly declare providers in modules that are intended to be used by other modules". References:

https://www.terraform.io/docs/configuration/modules.html#providers-within-modules 
https://github.com/hashicorp/terraform/issues/22907#issuecomment-535580358

You can repro the issue in current code by simply adding something like this to any parent module: 

```
module "bug_naming" {
  source = "Azure/naming/azurerm"
  suffix = [lower(var.datacenter), "dvo", lower(var.environment), lower(var.component)]
}

# This one doesn't matter, just use the bug_naming for something.
module "other_role_assignment" {
  source = "../../submodules/role-assignment"

  scope            = module.bug_naming.resource_group.name
  role_assignments = var.function_role_assignments
}
```

terragrunt/terraform apply, and then comment out those two resources and try to apply again. You will get 

```
Error: Provider configuration not present

To work with module.bug_naming.random_string.main its original provider
configuration at
module.bug_naming.provider["registry.terraform.io/hashicorp/random"] is
required, but it has been removed. 
```