### PR TITLE
Proper fix for 'Provider configuration not present'

### DIFF
--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -30,8 +30,6 @@ terraform {
   }
 }
 
-
-
 resource "random_string" "main" {
   length  = 60
   special = false

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -21,9 +21,16 @@
 
 
 {{- define "main" -}}
-provider "random" {
-  version = "~> 2.2"
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2"
+    }
+  }
 }
+
+
 
 resource "random_string" "main" {
   length  = 60


### PR DESCRIPTION
https://github.com/Azure/terraform-azurerm-naming/issues/31

My first PR was against the generated file instead of in the generation code itself, someone made me aware I needed to update the generator too. Whoops, here you go.