### PR TITLE
Add naming convention for: recovery_services_vault

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1646,6 +1646,16 @@ locals {
       scope       = "parent"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$"
     }
+    recovery_services_vault = {
+      name        = substr(join("-", compact([local.prefix, "rsv", local.suffix])), 0, 50)
+      name_unique = substr(join("-", compact([local.prefix, "rsv", local.suffix_unique])), 0, 50)
+      dashes      = true
+      slug        = "rsv"
+      min_length  = 2
+      max_length  = 50
+      scope       = "global"
+      regex       = "^[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]$"
+    }
     redis_cache = {
       name        = substr(join("-", compact([local.prefix, "redis", local.suffix])), 0, 63)
       name_unique = substr(join("-", compact([local.prefix, "redis", local.suffix_unique])), 0, 63)

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -1463,6 +1463,17 @@
     "dashes": true
   },
   {
+    "name": "recovery_services_vault",
+    "length": {
+      "min": 2,
+      "max": 50
+    },
+    "regex": "^(?=.{2,50}$)[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]$",
+    "scope": "global",
+    "slug": "rsv",
+    "dashes": true
+  },
+  {
     "name": "redis_cache",
     "length": {
       "min": 1,


### PR DESCRIPTION
Hi,
According to Azure naming convention, the recomended slug for "Recovery Services Vault" is "rsv":
https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging#management-and-governance

But this slug is nowadays assigned to a different resource which is marked as deprecated:
https://www.terraform.io/docs/providers/azurerm/r/hdinsight_rserver_cluster.html

The following PR adds this new resource allowing both of them to be used in parallel

Thank you