### PR TITLE
Correct link in README pointing to missing resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The resources are automatically generated using `go` to change the generation pl
 
 # Current implementation
 
-You can find a list bellow of all the resources that are currently implemented. To get a list of the ones that are missing implementation you can check at [Missing resources](docs/missing_ressources.md) the resources that have no documentation about their limitation on naming currently on Microsoft docs are on the [Not defined](docs/not_defined.md) list.
+You can find a list bellow of all the resources that are currently implemented. To get a list of the ones that are missing implementation you can check at [Missing resources](docs/missing_resources.md) the resources that have no documentation about their limitation on naming currently on Microsoft docs are on the [Not defined](docs/not_defined.md) list.
 
 
 # Advanced usage


### PR DESCRIPTION
Correct the link pointing to the missing resources documentation in the
README.

Resolves #44