### PR TITLE
Adding Cognitive Search naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ postgresql_server = {
 | cdn\_endpoint | n/a |
 | cdn\_profile | n/a |
 | cognitive\_account | n/a |
+| cognitive\_search | n/a |
 | container\_group | n/a |
 | container\_registry | n/a |
 | container\_registry\_webhook | n/a |

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -330,6 +330,17 @@
     "dashes": true
   },
   {
+    "name": "cognitive_search",
+    "length": {
+      "min": 2,
+      "max": 60
+    },
+    "regex": "^(?=.{1,60}$)[a-z0-9-]+$",
+    "scope": "resourceGroup",
+    "slug": "srch",
+    "dashes": true
+  },
+  {
     "name": "container_group",
     "length": {
       "min": 1,


### PR DESCRIPTION
Based on the document below the cognitive search abbreviation is `srch`

https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations#ai-and-machine-learning

when creating a resource in the portal the naming limits are:

> Service name must only contain lowercase letters, digits or dashes, cannot use dash as the first two or last one characters, cannot contain consecutive dashes, and is limited between 2 and 60 characters in length.

I believe this PR conforms to that (although my regex is questionable)