### PR TITLE
Bump Random Provider Version Requirement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
Raise the version of the random provider used. Solves a problem where this module will not work on the M1 Mac (darwin_arm64) due to older versions of the provider not supporting the platform.