### PR TITLE
Update hashicorp/random to 3.1.0 version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.1.0"
     }
   }
 }
@@ -20,8 +20,6 @@ resource "random_string" "first_letter" {
   upper   = false
   number  = false
 }
-
-
 
 locals {
   // adding a first letter to guarantee that you always start with a letter


### PR DESCRIPTION
hashicorp/random provider are deprecated on Terraform version 0.13 