### PR TITLE
Allow version 3 from root modules.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2"
     }
   }
 }

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = ">= 2.2"
     }
   }
 }


### PR DESCRIPTION
Trying to use version 3 of random breaks.

```
terraform {
  required_providers {
    random = {
      source = "hashicorp/random"
      version = "=3.1.0"
    }
  }
  required_version = ">=0.14.11"
}

module "naming" {
  source = "Azure/naming/azurerm"
}
```

output

```
terraform init
Initializing modules...
Downloading Azure/naming/azurerm 0.1.0 for naming...
- naming in .terraform\modules\naming

Initializing the backend...

Initializing provider plugins...
- Finding hashicorp/random versions matching "~> 2.2, 3.1.0"...

Warning: Version constraints inside provider configuration blocks are deprecated

  on .terraform\modules\naming\main.tf line 2, in provider "random":
   2:   version = "~> 2.2"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.


Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
hashicorp/random: no available releases match the given constraints ~> 2.2,
3.1.0
```

Might relate #38