### PR TITLE
use dash for 'api_management'

### DIFF
--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -19,7 +19,7 @@
     "regex": "^(?=.{1,50}$)[a-z][a-zA-Z0-9]+$",
     "scope": "global",
     "slug": "apim",
-    "dashes": false
+    "dashes": true
   },
   {
     "name": "app_configuration",


### PR DESCRIPTION
Add missing dash for `api_management` resource.