### PR TITLE
Add support for Azure SQL Managed Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ postgresql_server = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
 
 ## Modules
 
@@ -127,7 +127,7 @@ No modules.
 | <a name="output_api_management"></a> [api\_management](#output\_api\_management) | Api Management |
 | <a name="output_app_configuration"></a> [app\_configuration](#output\_app\_configuration) | App Configuration |
 | <a name="output_app_service"></a> [app\_service](#output\_app\_service) | App Service |
-| <a name="output_app_service_environment"></a> [app\_service\_environment](#output\_app\_service\_environment) | App Service Environment |
+| <a name="output_app_service_environment"></a> [app\_service\_environment](#output\_app\_service\_environment) | n/a |
 | <a name="output_app_service_plan"></a> [app\_service\_plan](#output\_app\_service\_plan) | App Service Plan |
 | <a name="output_application_gateway"></a> [application\_gateway](#output\_application\_gateway) | Application Gateway |
 | <a name="output_application_insights"></a> [application\_insights](#output\_application\_insights) | Application Insights |
@@ -248,14 +248,6 @@ No modules.
 | <a name="output_linux_virtual_machine_scale_set"></a> [linux\_virtual\_machine\_scale\_set](#output\_linux\_virtual\_machine\_scale\_set) | Linux Virtual Machine Scale Set |
 | <a name="output_local_network_gateway"></a> [local\_network\_gateway](#output\_local\_network\_gateway) | Local Network Gateway |
 | <a name="output_log_analytics_workspace"></a> [log\_analytics\_workspace](#output\_log\_analytics\_workspace) | Log Analytics Workspace |
-| <a name="output_monitor_action_group"></a> [monitor\_action\_group]
-(#output\_monitor\_action\_group) | Alerts Action group |
-| <a name="output_monitor_scheduled_query_rules_alert"></a> [monitor\_scheduled\_query\_rules\_alert]
-(#output\_monitor\_scheduled\_query\_rules\_alert) | Alerts scheduled query rules  |
-| <a name="output_monitor_autoscale_setting"></a> [monitor\_autoscale\_setting]
-(#output\_monitor\_autoscale\_setting) | Autoscale Setting |
-| <a name="output_monitor_diagnostic_setting"></a> [monitor\_diagnostic\_setting]
-(#output\_monitor\_diagnostic\_setting) | Siagnostic setting |
 | <a name="output_logic_app_workflow"></a> [logic\_app\_workflow](#output\_logic\_app\_workflow) | Logic App Workflow |
 | <a name="output_machine_learning_workspace"></a> [machine\_learning\_workspace](#output\_machine\_learning\_workspace) | Machine Learning Workspace |
 | <a name="output_managed_disk"></a> [managed\_disk](#output\_managed\_disk) | Managed Disk |
@@ -264,8 +256,13 @@ No modules.
 | <a name="output_mariadb_firewall_rule"></a> [mariadb\_firewall\_rule](#output\_mariadb\_firewall\_rule) | Mariadb Firewall Rule |
 | <a name="output_mariadb_server"></a> [mariadb\_server](#output\_mariadb\_server) | Mariadb Server |
 | <a name="output_mariadb_virtual_network_rule"></a> [mariadb\_virtual\_network\_rule](#output\_mariadb\_virtual\_network\_rule) | Mariadb Virtual Network Rule |
+| <a name="output_monitor_action_group"></a> [monitor\_action\_group](#output\_monitor\_action\_group) | Monitor Action Group |
+| <a name="output_monitor_autoscale_setting"></a> [monitor\_autoscale\_setting](#output\_monitor\_autoscale\_setting) | Monitor Autoscale Setting |
+| <a name="output_monitor_diagnostic_setting"></a> [monitor\_diagnostic\_setting](#output\_monitor\_diagnostic\_setting) | Monitor Diagnostic Setting |
+| <a name="output_monitor_scheduled_query_rules_alert"></a> [monitor\_scheduled\_query\_rules\_alert](#output\_monitor\_scheduled\_query\_rules\_alert) | Monitor Scheduled Query Rules Alert |
 | <a name="output_mssql_database"></a> [mssql\_database](#output\_mssql\_database) | Mssql Database |
 | <a name="output_mssql_elasticpool"></a> [mssql\_elasticpool](#output\_mssql\_elasticpool) | Mssql Elasticpool |
+| <a name="output_mssql_managed_instance"></a> [mssql\_managed\_instance](#output\_mssql\_managed\_instance) | Mssql Server Managed Instance |
 | <a name="output_mssql_server"></a> [mssql\_server](#output\_mssql\_server) | Mssql Server |
 | <a name="output_mysql_database"></a> [mysql\_database](#output\_mysql\_database) | Mysql Database |
 | <a name="output_mysql_firewall_rule"></a> [mysql\_firewall\_rule](#output\_mysql\_firewall\_rule) | Mysql Firewall Rule |

--- a/docs/defined_specs
+++ b/docs/defined_specs
@@ -51,6 +51,7 @@ az = {
     azure_data_warehouse       = "sqldw"
     azure_synapse_analytics    = "syn"
     sql_server_strech_database = "sqlstrdb"
+    mssql_managed_instance     = "sqlmi"
 
     // Storage
     storage_account                = "st"

--- a/main.tf
+++ b/main.tf
@@ -1436,6 +1436,16 @@ locals {
       scope       = "global"
       regex       = "^[a-z0-9][a-z0-9-]+[a-z0-9]$"
     }
+    mssql_managed_instance = {
+      name        = lower(substr(join("-", compact([local.prefix, "sqlmi", local.suffix])), 0, 63))
+      name_unique = lower(substr(join("-", compact([local.prefix, "sqlmi", local.suffix_unique])), 0, 63))
+      dashes      = true
+      slug        = "sqlmi"
+      min_length  = 1
+      max_length  = 63
+      scope       = "global"
+      regex       = "^[a-z0-9][a-z0-9-]+[a-z0-9]$"
+    }
     mysql_database = {
       name        = substr(join("-", compact([local.prefix, "mysqldb", local.suffix])), 0, 63)
       name_unique = substr(join("-", compact([local.prefix, "mysqldb", local.suffix_unique])), 0, 63)
@@ -2953,6 +2963,10 @@ locals {
     mssql_server = {
       valid_name        = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name)) > 0 && length(local.az.mssql_server.name) > local.az.mssql_server.min_length
       valid_name_unique = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name_unique)) > 0
+    }
+    mssql_managed_instance = {
+      valid_name        = length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name)) > 0 && length(local.az.mssql_managed_instance.name) > local.az.mssql_managed_instance.min_length
+      valid_name_unique = length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name_unique)) > 0
     }
     mysql_database = {
       valid_name        = length(regexall(local.az.mysql_database.regex, local.az.mysql_database.name)) > 0 && length(local.az.mysql_database.name) > local.az.mysql_database.min_length

--- a/outputs.tf
+++ b/outputs.tf
@@ -705,6 +705,11 @@ output "mssql_server" {
   description = "Mssql Server"
 }
 
+output "mssql_managed_instance" {
+  value       = local.az.mssql_managed_instance
+  description = "Mssql Server Managed Instance"
+}
+
 output "mysql_database" {
   value       = local.az.mysql_database
   description = "Mysql Database"

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -1342,6 +1342,17 @@
     "dashes": true
   },
   {
+    "name": "mssql_managed_instance",
+    "length": {
+      "min": 1,
+      "max": 63
+    },
+    "regex": "^(?=.{1,63}$)[a-z0-9][a-z0-9-]+[a-z0-9]$",
+    "scope": "global",
+    "slug": "sqlmi",
+    "dashes": true
+  },
+  {
     "name": "mysql_database",
     "length": {
       "min": 1,


### PR DESCRIPTION
- Added support for Azure SQL Managed Instance naming according to [MS abbreviation recommendation](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations#databases)
- Pre-commit hook ran (other outdated information out of the scope of this change were updated along in README file)