### PR TITLE
Enable use of hyphen for API Management resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,14 +47,14 @@ locals {
       regex       = "^[a-z][a-z0-9]+$"
     }
     api_management = {
-      name        = substr(join("", compact([local.prefix_safe, "apim", local.suffix_safe])), 0, 50)
-      name_unique = substr(join("", compact([local.prefix_safe, "apim", local.suffix_unique_safe])), 0, 50)
-      dashes      = false
+      name        = substr(join("-", compact([local.prefix, "apim", local.suffix])), 0, 50)
+      name_unique = substr(join("-", compact([local.prefix, "apim", local.suffix_unique])), 0, 50)
+      dashes      = true
       slug        = "apim"
       min_length  = 1
       max_length  = 50
       scope       = "global"
-      regex       = "^[a-z][a-zA-Z0-9]+$"
+      regex       = "^[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]+$"
     }
     app_configuration = {
       name        = substr(join("-", compact([local.prefix, "appcg", local.suffix])), 0, 50)

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -16,10 +16,10 @@
       "min": 1,
       "max": 50
     },
-    "regex": "^(?=.{1,50}$)[a-z][a-zA-Z0-9]+$",
+    "regex": "^(?=.{1,50}$)[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]+$",
     "scope": "global",
     "slug": "apim",
-    "dashes": false
+    "dashes": true
   },
   {
     "name": "app_configuration",


### PR DESCRIPTION
This supersedes #93, as that has been stale for 10 months now, without the required changes to merge.

Azure's [naming restrictions for API Management resources](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftapimanagement) is:
```
Alphanumerics and hyphens.
Start with letter and end with alphanumeric.
```
As referenced in [a comment on #93](https://github.com/Azure/terraform-azurerm-naming/pull/93#issuecomment-1665674792), Microsoft has [example docs presented in a hyphenated format](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming#example-names-general).

Until now, the APIM naming schema generated by this module had hyphens disabled.
This PR changes that, and tweaks the regex to properly match the above naming conditions.
