### PR TITLE
Order mssql_server and mssql_managed_instance blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1446,21 +1446,21 @@ locals {
       scope       = "parent"
       regex       = "^[^<>*%:.?\\+\\/]+[^<>*%:.?\\+\\/ ]$"
     }
-    mssql_server = {
-      name        = substr(join("-", compact([local.prefix, "sql", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
+    mssql_managed_instance = {
+      name        = substr(join("-", compact([local.prefix, "sqlmi", local.suffix])), 0, 63)
+      name_unique = substr(join("-", compact([local.prefix, "sqlmi", local.suffix_unique])), 0, 63)
       dashes      = true
-      slug        = "sql"
+      slug        = "sqlmi"
       min_length  = 1
       max_length  = 63
       scope       = "global"
       regex       = "^[a-z0-9][a-z0-9-]+[a-z0-9]$"
     }
-    mssql_managed_instance = {
-      name        = lower(substr(join("-", compact([local.prefix, "sqlmi", local.suffix])), 0, 63))
-      name_unique = lower(substr(join("-", compact([local.prefix, "sqlmi", local.suffix_unique])), 0, 63))
+    mssql_server = {
+      name        = substr(join("-", compact([local.prefix, "sql", local.suffix])), 0, 63)
+      name_unique = substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
       dashes      = true
-      slug        = "sqlmi"
+      slug        = "sql"
       min_length  = 1
       max_length  = 63
       scope       = "global"
@@ -3012,13 +3012,13 @@ locals {
       valid_name        = length(regexall(local.az.mssql_elasticpool.regex, local.az.mssql_elasticpool.name)) > 0 && length(local.az.mssql_elasticpool.name) > local.az.mssql_elasticpool.min_length
       valid_name_unique = length(regexall(local.az.mssql_elasticpool.regex, local.az.mssql_elasticpool.name_unique)) > 0
     }
-    mssql_server = {
-      valid_name        = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name)) > 0 && length(local.az.mssql_server.name) > local.az.mssql_server.min_length
-      valid_name_unique = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name_unique)) > 0
-    }
     mssql_managed_instance = {
       valid_name        = length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name)) > 0 && length(local.az.mssql_managed_instance.name) > local.az.mssql_managed_instance.min_length
       valid_name_unique = length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name_unique)) > 0
+    }
+    mssql_server = {
+      valid_name        = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name)) > 0 && length(local.az.mssql_server.name) > local.az.mssql_server.min_length
+      valid_name_unique = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name_unique)) > 0
     }
     mysql_database = {
       valid_name        = length(regexall(local.az.mysql_database.regex, local.az.mysql_database.name)) > 0 && length(local.az.mysql_database.name) > local.az.mysql_database.min_length

--- a/outputs.tf
+++ b/outputs.tf
@@ -711,14 +711,14 @@ output "mssql_elasticpool" {
   description = "Mssql Elasticpool"
 }
 
+output "mssql_managed_instance" {
+  value       = local.az.mssql_managed_instance
+  description = "Mssql Managed Instance"
+}
+
 output "mssql_server" {
   value       = local.az.mssql_server
   description = "Mssql Server"
-}
-
-output "mssql_managed_instance" {
-  value       = local.az.mssql_managed_instance
-  description = "Mssql Server Managed Instance"
 }
 
 output "mysql_database" {


### PR DESCRIPTION
[8a1c861](https://github.com/Azure/terraform-azurerm-naming/commit/8a1c8616d4cd05423e53c3260a016919ce0df33d) added support for mssql_managed_instance, but when running `make generate` since then, it is swapping the order of `mssql_managed_instance` and `mssql_server` due to alphabetic sorting order.
Had this cluttering my changes while opening another PR, and presumably this will impact anyone making changes to the naming rules in this repo until committed.