### PR TITLE
Fix ServiceBus Namespace Slug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1947,10 +1947,10 @@ locals {
       regex       = "^[a-z][a-z0-9-]+[a-z0-9]$"
     }
     servicebus_namespace = {
-      name        = substr(join("-", compact([local.prefix, "sb", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "sb", local.suffix_unique])), 0, 50)
+      name        = substr(join("-", compact([local.prefix, "sbus", local.suffix])), 0, 50)
+      name_unique = substr(join("-", compact([local.prefix, "sbus", local.suffix_unique])), 0, 50)
       dashes      = true
-      slug        = "sb"
+      slug        = "sbus"
       min_length  = 6
       max_length  = 50
       scope       = "global"

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -1767,7 +1767,7 @@
     },
     "regex": "^(?=.{6,50}$)[a-zA-Z][a-zA-Z0-9-]+[a-zA-Z0-9]$",
     "scope": "global",
-    "slug": "sb",
+    "slug": "sbus",
     "dashes": true
   },
   {


### PR DESCRIPTION
This is the PR for fixing ServiceBus Namespace slug coming from naming module, when using module.naming.servicebus_namespace.name it is throwing an error stating,

**Error:  "name" cannot end with a hyphen, -sb, or -mgmt │ 
│   with module.service_bus.azurerm_servicebus_namespace.this,
│   on .terraform/modules/service_bus/main.tf line 3, in resource "azurerm_servicebus_namespace" "this":
│    3:   name                          = var.name**

**current Behaviour:**
-sb

**Expected Behaviour to resolve issue**
-sbus

**Reference documentation:**
https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quickstart-topics-subscriptions-portal

![image](https://github.com/user-attachments/assets/760af270-8e69-49d1-b779-c80995f316a9)



