### PR TITLE
fix: naming for route and route table according to azure abbreviation…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1907,20 +1907,20 @@ locals {
       regex       = "^[^%]+[^ %.]$"
     }
     route = {
-      name        = substr(join("-", compact([local.prefix, "rt", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "rt", local.suffix_unique])), 0, 80)
+      name        = substr(join("-", compact([local.prefix, "udr", local.suffix])), 0, 80)
+      name_unique = substr(join("-", compact([local.prefix, "udr", local.suffix_unique])), 0, 80)
       dashes      = true
-      slug        = "rt"
+      slug        = "udr"
       min_length  = 1
       max_length  = 80
       scope       = "parent"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$"
     }
     route_table = {
-      name        = substr(join("-", compact([local.prefix, "route", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "route", local.suffix_unique])), 0, 80)
+      name        = substr(join("-", compact([local.prefix, "rt", local.suffix])), 0, 80)
+      name_unique = substr(join("-", compact([local.prefix, "rt", local.suffix_unique])), 0, 80)
       dashes      = true
-      slug        = "route"
+      slug        = "rt"
       min_length  = 1
       max_length  = 80
       scope       = "resourceGroup"

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -1723,7 +1723,7 @@
     },
     "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
     "scope": "parent",
-    "slug": "rt",
+    "slug": "udr",
     "dashes": true
   },
   {
@@ -1734,7 +1734,7 @@
     },
     "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
     "scope": "resourceGroup",
-    "slug": "route",
+    "slug": "rt",
     "dashes": true
   },
   {


### PR DESCRIPTION
Hello,

I think the abbreviations for the user defined route and the route table were not correct. I updated it according to the Azure abbreviation recommendation.

Azure abbreviation recommendation:
https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations

BR
Daniel