### PR TITLE
Added missing undocumented Abbreviations

### DIFF
--- a/docs/defined_specs
+++ b/docs/defined_specs
@@ -23,6 +23,7 @@ az = {
     private_service_connection = "psc"   // Not in the specs
     firewall                   = "fw"    // Not in the specs
     firewall_ip_configuration  = "fwipc" // Not in the specs
+    private_dns_zone_virtual_network_link = "pnetlk" // Not in the specs
 
     // Compute and Web
     virtual_machine             = "vm"
@@ -54,6 +55,9 @@ az = {
     azure_synapse_analytics    = "syn"
     sql_server_strech_database = "sqlstrdb"
     mssql_managed_instance     = "sqlmi"
+    postgresql_flexible_server = "psqlf" // Not in the specs
+    postgresql_flexible_server_database = "psqlfdb" // Not in the specs
+
 
     // Storage
     storage_account                = "st"

--- a/main.tf
+++ b/main.tf
@@ -1666,6 +1666,26 @@ locals {
       scope       = "parent"
       regex       = "^[a-zA-Z0-9-_]+$"
     }
+    postgresql_flexible_server = {
+      name        = substr(join("-", compact([local.prefix, "psqlf", local.suffix])), 0, 63)
+      name_unique = substr(join("-", compact([local.prefix, "psqlf", local.suffix_unique])), 0, 63)
+      dashes      = true
+      slug        = "psqlf"
+      min_length  = 3
+      max_length  = 63
+      scope       = "global"
+      regex       = "^[a-z0-9][a-zA-Z0-9-]+[a-z0-9]$"
+    }
+     postgresql_flexible_server_database = {
+      name        = substr(join("-", compact([local.prefix, "psqlfdb", local.suffix])), 0, 63)
+      name_unique = substr(join("-", compact([local.prefix, "psqlfdb", local.suffix_unique])), 0, 63)
+      dashes      = true
+      slug        = "psqlfdb"
+      min_length  = 1
+      max_length  = 63
+      scope       = "global"
+      regex       = "^[a-z0-9][a-zA-Z0-9-]+[a-z0-9]$"
+    }
     powerbi_embedded = {
       name        = substr(join("-", compact([local.prefix, "pbi", local.suffix])), 0, 63)
       name_unique = substr(join("-", compact([local.prefix, "pbi", local.suffix_unique])), 0, 63)
@@ -1764,6 +1784,16 @@ locals {
       min_length  = 1
       max_length  = 80
       scope       = "resourceGroup"
+      regex       = "^[a-zA-Z0-9][a-zA-Z0-9\\-\\._]+[a-zA-Z0-9_]$"
+    }
+    private_dns_zone_virtual_network_link = {
+      name        = substr(join("-", compact([local.prefix, "pnetlk", local.suffix])), 0, 80)
+      name_unique = substr(join("-", compact([local.prefix, "pnetlk", local.suffix_unique])), 0, 80)
+      dashes      = true
+      slug        = "pnetlk"
+      min_length  = 1
+      max_length  = 80
+      scope       = "parent"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9\\-\\._]+[a-zA-Z0-9_]$"
     }
     private_endpoint = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -816,6 +816,16 @@ output "postgresql_server" {
   description = "Postgresql Server"
 }
 
+output "postgresql_flexible_server" {
+  value       = local.az.postgresql_flexible_server
+  description = "Postgresql Flexible Server"
+}
+
+output "postgresql_flexible_server_database" {
+  value       = local.az.postgresql_flexible_server_database
+  description = "Postgresql Flexible Server Database"
+}
+
 output "postgresql_virtual_network_rule" {
   value       = local.az.postgresql_virtual_network_rule
   description = "Postgresql Virtual Network Rule"
@@ -869,6 +879,11 @@ output "private_dns_zone" {
 output "private_dns_zone_group" {
   value       = local.az.private_dns_zone_group
   description = "Private Dns Zone Group"
+}
+
+output "private_dns_zone_virtual_network_link" {
+  value       = local.az.private_dns_zone_virtual_network_link
+  description = "Private Dns Zone Virtual Network Link"
 }
 
 output "private_endpoint" {

--- a/resourceDefinition_out_of_docs.json
+++ b/resourceDefinition_out_of_docs.json
@@ -211,8 +211,8 @@
   {
     "name": "postgresql_flexible_server",
     "length": {
-      "min": 1,
-      "max": 80
+      "min": 3,
+      "max": 63
     },
     "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
     "scope": "global",
@@ -223,7 +223,7 @@
     "name": "postgresql_flexible_server_database",
     "length": {
       "min": 1,
-      "max": 80
+      "max": 63
     },
     "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
     "scope": "parent",

--- a/resourceDefinition_out_of_docs.json
+++ b/resourceDefinition_out_of_docs.json
@@ -209,6 +209,28 @@
     "dashes": true
   },
   {
+    "name": "postgresql_flexible_server",
+    "length": {
+      "min": 1,
+      "max": 80
+    },
+    "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
+    "scope": "global",
+    "slug": "psqlf",
+    "dashes": true
+  },
+  {
+    "name": "postgresql_flexible_server_database",
+    "length": {
+      "min": 1,
+      "max": 80
+    },
+    "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
+    "scope": "parent",
+    "slug": "psqlfdb",
+    "dashes": true
+  },
+  {
     "name": "private_dns_a_record",
     "length": {
       "min": 1,
@@ -294,6 +316,17 @@
     "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9\\\\-\\\\._]+[a-zA-Z0-9_]$",
     "scope": "resourceGroup",
     "slug": "pdnszg",
+    "dashes": true
+  },
+  {
+    "name": "private_dns_zone_virtual_network_link",
+    "length": {
+      "min": 1,
+      "max": 80
+    },
+    "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9\\\\-\\\\._]+[a-zA-Z0-9_]$",
+    "scope": "parent",
+    "slug": "pnetlk",
     "dashes": true
   },
   {


### PR DESCRIPTION
Hey there, my first public contribution, hopefully as complete and correct as its need to be.

This pull request adds support for new Azure resources, specifically PostgreSQL Flexible Server and Private DNS Zone Virtual Network Link, to the Terraform configuration. The changes include updates to resource definitions, local variables, and outputs.

### Resource Definitions:
* Added `postgresql_flexible_server`, `postgresql_flexible_server_database` and `private_dns_zone_virtual_network_link` definitions with their respective properties in `resourceDefinition_out_of_docs.json`. [[1]](diffhunk://#diff-00e081acb1142748a7903f7c98d2285daa59e74af545a68e8b90d62f3274fe0dR211-R232) [[2]](diffhunk://#diff-00e081acb1142748a7903f7c98d2285daa59e74af545a68e8b90d62f3274fe0dR321-R331)

### Local Variables:
* Defined `postgresql_flexible_server` and `postgresql_flexible_server_database` with their naming conventions and constraints in `main.tf`.
* Defined `private_dns_zone_virtual_network_link` with its naming conventions and constraints in `main.tf`.

### Outputs:
* Added outputs for `postgresql_flexible_server`, `postgresql_flexible_server_database`, and `private_dns_zone_virtual_network_link` in `outputs.tf`. [[1]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R819-R828) [[2]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R884-R888)

### Documentation:
* Updated `docs/defined_specs` to include abbreviations for `postgresql_flexible_server`, `postgresql_flexible_server_database`, and `private_dns_zone_virtual_network_link`. [[1]](diffhunk://#diff-f03b347fb9a2c4b0ba4044ec11d0e749021c626dfbb84877ecbbe10602cc5074R26) [[2]](diffhunk://#diff-f03b347fb9a2c4b0ba4044ec11d0e749021c626dfbb84877ecbbe10602cc5074R58-R60)