### PR TITLE
Add Resource: ExpressRoute Direct

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -916,6 +916,16 @@ locals {
       scope       = "resourceGroup"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$"
     }
+    express_route_direct = {
+      name        = substr(join("-", compact([local.prefix, "erd", local.suffix])), 0, 80)
+      name_unique = substr(join("-", compact([local.prefix, "erd", local.suffix_unique])), 0, 80)
+      dashes      = true
+      slug        = "erd"
+      min_length  = 1
+      max_length  = 80
+      scope       = "resourceGroup"
+      regex       = "^[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$"
+    }
     express_route_gateway = {
       name        = substr(join("-", compact([local.prefix, "ergw", local.suffix])), 0, 80)
       name_unique = substr(join("-", compact([local.prefix, "ergw", local.suffix_unique])), 0, 80)
@@ -2849,6 +2859,10 @@ locals {
     express_route_circuit = {
       valid_name        = length(regexall(local.az.express_route_circuit.regex, local.az.express_route_circuit.name)) > 0 && length(local.az.express_route_circuit.name) > local.az.express_route_circuit.min_length
       valid_name_unique = length(regexall(local.az.express_route_circuit.regex, local.az.express_route_circuit.name_unique)) > 0
+    }
+    express_route_direct = {
+      valid_name        = length(regexall(local.az.express_route_direct.regex, local.az.express_route_direct.name)) > 0 && length(local.az.express_route_direct.name) > local.az.express_route_direct.min_length
+      valid_name_unique = length(regexall(local.az.express_route_direct.regex, local.az.express_route_direct.name_unique)) > 0
     }
     express_route_gateway = {
       valid_name        = length(regexall(local.az.express_route_gateway.regex, local.az.express_route_gateway.name)) > 0 && length(local.az.express_route_gateway.name) > local.az.express_route_gateway.min_length

--- a/outputs.tf
+++ b/outputs.tf
@@ -446,6 +446,11 @@ output "express_route_circuit" {
   description = "Express Route Circuit"
 }
 
+output "express_route_direct" {
+  value       = local.az.express_route_direct
+  description = "Express Route Direct"
+}
+
 output "express_route_gateway" {
   value       = local.az.express_route_gateway
   description = "Express Route Gateway"

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -825,6 +825,17 @@
     "dashes": true
   },
   {
+    "name": "express_route_direct",
+    "length": {
+      "min": 1,
+      "max": 80
+    },
+    "regex": "^(?=.{1,80}$)[a-zA-Z0-9][a-zA-Z0-9-._]+[a-zA-Z0-9_]$",
+    "scope": "resourceGroup",
+    "slug": "erd",
+    "dashes": true
+  },
+  {
     "name": "express_route_gateway",
     "length": {
       "min": 1,


### PR DESCRIPTION
Adding missing resource

In accordance with the Azure naming convention, resource Express Route Direct should begin with erd
https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations#networking