### PR TITLE
feat: Add JSON Schema for resource definitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "resourceDefinition.json",
+        "resourceDefinition_out_of_docs.json"
+      ],
+      "url": "./resourceDefinition.schema.json"
+    }
+  ]
+}

--- a/resourceDefinition.json
+++ b/resourceDefinition.json
@@ -1272,7 +1272,7 @@
       "max": 64
     },
     "regex": "^(?=.{3,64}$)[a-zA-Z0-9-]+[a-zA-Z0-9]$",
-    "scope": "resoureceGroup",
+    "scope": "resourceGroup",
     "slug": "dps",
     "dashes": true
   },

--- a/resourceDefinition.schema.json
+++ b/resourceDefinition.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Azure/terraform-azurerm-naming/resourceDefinition.schema.json",
+  "title": "Azure Resource Definition",
+  "description": "Schema for validating Azure resource naming definitions used by terraform-azurerm-naming module",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/resourceDefinition"
+  },
+  "definitions": {
+    "resourceDefinition": {
+      "type": "object",
+      "description": "Definition of an Azure resource's naming constraints and conventions",
+      "required": ["name", "length", "scope", "slug", "dashes"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The resource identifier using snake_case format (e.g., 'storage_account', 'virtual_network')",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "length": {
+          "type": "object",
+          "description": "The minimum and maximum allowed length for the resource name",
+          "required": ["min", "max"],
+          "properties": {
+            "min": {
+              "type": "integer",
+              "description": "Minimum allowed length for the resource name",
+              "minimum": 1
+            },
+            "max": {
+              "type": "integer",
+              "description": "Maximum allowed length for the resource name",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "regex": {
+          "type": "string",
+          "description": "Regular expression pattern for validating the resource name format"
+        },
+        "scope": {
+          "type": "string",
+          "description": "The uniqueness scope for the resource name. Determines where the name must be unique.",
+          "enum": [
+            "global",
+            "resourceGroup",
+            "parent",
+            "region",
+            "tenant",
+            "subscription",
+            "assignment",
+            "definition"
+          ]
+        },
+        "slug": {
+          "type": "string",
+          "description": "Short abbreviation used as a prefix/suffix in the generated resource name (e.g., 'st' for storage_account, 'vnet' for virtual_network)",
+          "pattern": "^[a-z][a-z0-9]*$"
+        },
+        "dashes": {
+          "type": "boolean",
+          "description": "Whether dashes (hyphens) are allowed in the resource name"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `resourceDefinition.schema.json` with JSON Schema draft-07 validation for resource definitions
- Add `.vscode/settings.json` for automatic schema validation in VS Code
- Fix typo in `iothub_dps` scope: `resoureceGroup` -> `resourceGroup`

## Schema Properties

The schema validates all properties of resource definitions:

| Property | Type | Required | Description |
|----------|------|----------|-------------|
| `name` | string | Yes | Resource identifier in snake_case format (e.g., `storage_account`) |
| `length` | object | Yes | Object with `min` and `max` integer constraints |
| `regex` | string | No | Regular expression for validating resource name format |
| `scope` | enum | Yes | Uniqueness scope: `global`, `resourceGroup`, `parent`, `region`, `tenant`, `subscription`, `assignment`, `definition` |
| `slug` | string | Yes | Short abbreviation for naming (e.g., `st`, `vnet`) |
| `dashes` | boolean | Yes | Whether hyphens are allowed in the resource name |

## Benefits

- IDE validation and autocomplete when editing resource definitions
- Self-documenting structure for contributors  
- Catches errors before running the generator

## IDE Usage

For VS Code users, the schema is automatically applied via `.vscode/settings.json`.

For other IDEs, configure your JSON language server to use `resourceDefinition.schema.json` for files matching `resourceDefinition*.json`.

## Validation

Both `resourceDefinition.json` (264 entries) and `resourceDefinition_out_of_docs.json` (34 entries) pass schema validation.

Closes #185