### PR TITLE
docs: Fix typos in source files and generated comments

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ type Resource struct {
 	Dashes bool    `json:"dashes"`
 }
 
-// Length allowed for that resorce
+// Length allowed for that resource
 type Length struct {
 	Min int `json:"min"`
 	Max int `json:"max"`

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ locals {
   suffix_unique          = join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
   suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
-  // Names based in the recomendations of
+  // Names based on the recommendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {
     analysis_services_server = {

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -56,7 +56,7 @@ locals {
   suffix_unique          = join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
   suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
-  // Names based in the recomendations of
+  // Names based on the recommendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {
     {{- range . }}


### PR DESCRIPTION
## Summary
- Fixed typo `resorce` → `resource` in main.go comment (line 28)
- Fixed typo `recomendations` → `recommendations` in templates/main.tmpl (line 59)
- Also fixed `based in` → `based on` for better grammar
- Regenerated main.tf with corrected comments

## Non-Breaking
These are comment-only changes in source files. The generated Terraform files have the typo fix in the comment, but this does not affect any module behavior or outputs.

Closes #186