### PR TITLE
chore: Replace deprecated ioutil with os package

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -31,7 +30,7 @@ type Length struct {
 }
 
 func main() {
-	files, err := ioutil.ReadDir("templates")
+	files, err := os.ReadDir("templates")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -53,7 +52,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	sourceDefinitions, err := ioutil.ReadFile("resourceDefinition.json")
+	sourceDefinitions, err := os.ReadFile("resourceDefinition.json")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -64,7 +63,7 @@ func main() {
 	}
 
 	// Undocumented resource definitions
-	sourceDefinitionsUndocumented, err := ioutil.ReadFile("resourceDefinition_out_of_docs.json")
+	sourceDefinitionsUndocumented, err := os.ReadFile("resourceDefinition_out_of_docs.json")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Replace deprecated `io/ioutil` functions with their `os` package equivalents as recommended since Go 1.16
- `ioutil.ReadDir` -> `os.ReadDir`
- `ioutil.ReadFile` -> `os.ReadFile`

## Details

The `io/ioutil` package was deprecated in Go 1.16 (see [release notes](https://go.dev/doc/go1.16#ioutil)). This PR modernizes the codebase by using the recommended replacements from the `os` package.

## Verification

This is a **no-op change** - the generated Terraform files (`main.tf`, `outputs.tf`) are identical before and after this change. The `os.ReadDir` function returns `[]os.DirEntry` instead of `[]os.FileInfo`, but both types have a `Name()` method, so the existing code works without modification.

Closes #188