### PR TITLE
ci: Update GitHub Actions and pre-commit hook versions

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -7,8 +7,18 @@ jobs:
     name: TF Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: hashicorp/setup-terraform@v1
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - uses: hashicorp/setup-terraform@v3
+
+      - name: Verify generated files are up-to-date
+        run: |
+          go run main.go
+          git diff --exit-code main.tf outputs.tf || (echo "Generated files are out of date. Run 'make generate' and commit the changes." && exit 1)
 
       - name: Terraform fmt
         id: fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@
 # See http://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.74.1
+    rev: v1.104.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace


### PR DESCRIPTION
## Summary

- Update GitHub Actions workflow action versions and add generation verification
- Update pre-commit hook versions to latest stable releases

Closes #189

## Changes

### GitHub Actions (.github/workflows/pr-validation.yaml)

- `actions/checkout@v2` → `actions/checkout@v4`
- `hashicorp/setup-terraform@v1` → `hashicorp/setup-terraform@v3`
- Added `actions/setup-go@v5` with Go 1.23
- Added new step to verify generated files (`main.tf`, `outputs.tf`) are up-to-date by running `go run main.go` and checking for uncommitted changes

### Pre-commit hooks (.pre-commit-config.yaml)

- `pre-commit-terraform` from `v1.74.1` → `v1.104.0`
- `pre-commit-hooks` from `v4.3.0` → `v5.0.0`

## Why

- Security updates from newer action versions
- Ensures PRs don't forget to regenerate files after changing templates or resourceDefinition.json
- Better developer experience with updated pre-commit tooling