### PR TITLE
docs: fix typos in generator and template comments

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ type Resource struct {
 	Dashes bool    `json:"dashes"`
 }
 
-// Length allowed for that resorce
+// Length allowed for that resource
 type Length struct {
 	Min int `json:"min"`
 	Max int `json:"max"`

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "random_string" "first_letter" {
 
 
 locals {
-  // adding a first letter to guarantee that you always start with a letter
+  // Add a leading letter to ensure generated names always start with a letter
   random_safe_generation = join("", [random_string.first_letter.result, random_string.main.result])
   random                 = substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
   prefix                 = join("-", var.prefix)
@@ -33,7 +33,7 @@ locals {
   suffix_unique          = join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
   suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
-  // Names based in the recomendations of
+  // Names based on the recommendations from
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {
     analysis_services_server = {

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -47,7 +47,7 @@ resource "random_string" "first_letter" {
 
 
 locals {
-  // adding a first letter to guarantee that you always start with a letter
+  // Add a leading letter to ensure generated names always start with a letter
   random_safe_generation = join("", [random_string.first_letter.result, random_string.main.result])
   random                 = substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
   prefix                 = join("-", var.prefix)
@@ -56,7 +56,7 @@ locals {
   suffix_unique          = join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
   suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
-  // Names based in the recomendations of
+  // Names based on the recommendations from
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {
     {{- range . }}


### PR DESCRIPTION
## Summary
- fix typo in `main.go` comment (`resorce` → `resource`)
- fix typo in `templates/main.tmpl` comment (`recomendations` → `recommendations`)
- improve wording of the generated-name comment for clarity
- sync generated comment text in `main.tf` to match template updates

## Validation
- confirmed removed typo strings no longer appear via `git grep`
- attempted to run generation/terraform checks, but `go` and `terraform` are not available in this environment

Fixes Azure/terraform-azurerm-naming#186