### PR TITLE
feat: Add unique-disabled variable to skip random_string resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Each one of the resources emits the name of the resource and other properties:
 | Property | Type | Description |
 | ----- |----- | ---- |
 | name | string | name of the resource including respective suffixes and prefixes applied |
-| name_unique | string | same as the name but with random chars added for uniqueness |
+| name_unique | string or null | same as the name but with random chars added for uniqueness (`null` when `unique-disabled` is `true`) |
 | dashes | bool | if these resources support dashes |
 | slug | string | letters to identify this resource among others |
 | min_length | integer | Minimum length required for this resource name |
@@ -102,6 +102,7 @@ postgresql_server = {
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
 
 ## Providers
@@ -127,7 +128,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | It is not recommended that you use prefix by azure you should be using a suffix for your resources. | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | It is recommended that you specify a suffix for consistency. please use only lowercase characters when possible | `list(string)` | `[]` | no |
-| <a name="input_unique-disabled"></a> [unique-disabled](#input\_unique-disabled) | If you want to disable the generation of unique random names | `bool` | `false` | no |
+| <a name="input_unique-disabled"></a> [unique-disabled](#input\_unique-disabled) | If you want to disable the generation of unique random names. When set to true, all name\_unique outputs and the unique-seed output will be null. | `bool` | `false` | no |
 | <a name="input_unique-include-numbers"></a> [unique-include-numbers](#input\_unique-include-numbers) | If you want to include numbers in the unique generation | `bool` | `true` | no |
 | <a name="input_unique-length"></a> [unique-length](#input\_unique-length) | Max length of the uniqueness suffix to be added | `number` | `4` | no |
 | <a name="input_unique-seed"></a> [unique-seed](#input\_unique-seed) | Custom value for the random characters to be used | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ resource "azurerm_resource_group" "example" {
 }
 ```
 
-The `random_string` resources used to generate the unique suffix are only created when `unique-seed` is not set and `unique-disabled` is `false` (default). If you provide a custom `unique-seed`, that value is used instead of the random generation. If you set `unique-disabled` to `true`, the `name_unique` property of all resources will be `null` and no `random_string` resources will be stored in the state.
+The `random_string` resources used to generate the unique suffix are only created when `unique-seed` is not set and `unique-disabled` is `false` (default). If you provide a custom `unique-seed`, that value is used instead of the random generation. If you set `unique-disabled` to `true`, the `name_unique` property of all resources and the `unique-seed` output will be `null` and no `random_string` resources will be stored in the state.
 
 ```tf
 module "naming" {

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ resource "azurerm_resource_group" "example" {
 }
 ```
 
+The `random_string` resources used to generate the unique suffix are only created when `unique-seed` is not set and `unique-disabled` is `false` (default). If you provide a custom `unique-seed`, that value is used instead of the random generation. If you set `unique-disabled` to `true`, the `name_unique` property of all resources will be `null` and no `random_string` resources will be stored in the state.
+
+```tf
+module "naming" {
+  source          = "Azure/naming/azurerm"
+  suffix          = [ "test" ]
+  unique-disabled = true
+}
+```
+
 Other advanced usages will be explained in the [Advanced usage](#advanced-usage) part of this docs.
 
 ## Internals
@@ -98,7 +108,7 @@ postgresql_server = {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 
 ## Modules
 
@@ -117,6 +127,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | It is not recommended that you use prefix by azure you should be using a suffix for your resources. | `list(string)` | `[]` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | It is recommended that you specify a suffix for consistency. please use only lowercase characters when possible | `list(string)` | `[]` | no |
+| <a name="input_unique-disabled"></a> [unique-disabled](#input\_unique-disabled) | If you want to disable the generation of unique random names | `bool` | `false` | no |
 | <a name="input_unique-include-numbers"></a> [unique-include-numbers](#input\_unique-include-numbers) | If you want to include numbers in the unique generation | `bool` | `true` | no |
 | <a name="input_unique-length"></a> [unique-length](#input\_unique-length) | Max length of the uniqueness suffix to be added | `number` | `4` | no |
 | <a name="input_unique-seed"></a> [unique-seed](#input\_unique-seed) | Custom value for the random characters to be used | `string` | `""` | no |
@@ -129,7 +140,7 @@ No modules.
 | <a name="output_api_management"></a> [api\_management](#output\_api\_management) | Api Management |
 | <a name="output_app_configuration"></a> [app\_configuration](#output\_app\_configuration) | App Configuration |
 | <a name="output_app_service"></a> [app\_service](#output\_app\_service) | App Service |
-| <a name="output_app_service_environment"></a> [app\_service\_environment](#output\_app\_service\_environment) | n/a |
+| <a name="output_app_service_environment"></a> [app\_service\_environment](#output\_app\_service\_environment) | App Service Environment |
 | <a name="output_app_service_plan"></a> [app\_service\_plan](#output\_app\_service\_plan) | App Service Plan |
 | <a name="output_application_gateway"></a> [application\_gateway](#output\_application\_gateway) | Application Gateway |
 | <a name="output_application_insights"></a> [application\_insights](#output\_application\_insights) | Application Insights |
@@ -141,6 +152,7 @@ No modules.
 | <a name="output_automation_schedule"></a> [automation\_schedule](#output\_automation\_schedule) | Automation Schedule |
 | <a name="output_automation_variable"></a> [automation\_variable](#output\_automation\_variable) | Automation Variable |
 | <a name="output_availability_set"></a> [availability\_set](#output\_availability\_set) | Availability Set |
+| <a name="output_backup_policy_vm"></a> [backup\_policy\_vm](#output\_backup\_policy\_vm) | Backup Policy Vm |
 | <a name="output_bastion_host"></a> [bastion\_host](#output\_bastion\_host) | Bastion Host |
 | <a name="output_batch_account"></a> [batch\_account](#output\_batch\_account) | Batch Account |
 | <a name="output_batch_application"></a> [batch\_application](#output\_batch\_application) | Batch Application |
@@ -153,12 +165,12 @@ No modules.
 | <a name="output_bot_channels_registration"></a> [bot\_channels\_registration](#output\_bot\_channels\_registration) | Bot Channels Registration |
 | <a name="output_bot_connection"></a> [bot\_connection](#output\_bot\_connection) | Bot Connection |
 | <a name="output_bot_web_app"></a> [bot\_web\_app](#output\_bot\_web\_app) | Bot Web App |
-| <a name="output_cdn_frontdoor_endpoint"></a> [cnd\_frontdoor\_endpoint](#output\_cdn\_frontdoor\_endpoint) | Cdn Frontdoor Endpoint |
+| <a name="output_cdn_endpoint"></a> [cdn\_endpoint](#output\_cdn\_endpoint) | Cdn Endpoint |
+| <a name="output_cdn_frontdoor_endpoint"></a> [cdn\_frontdoor\_endpoint](#output\_cdn\_frontdoor\_endpoint) | Cdn Frontdoor Endpoint |
 | <a name="output_cdn_frontdoor_origin"></a> [cdn\_frontdoor\_origin](#output\_cdn\_frontdoor\_origin) | Cdn Frontdoor Origin |
 | <a name="output_cdn_frontdoor_origin_group"></a> [cdn\_frontdoor\_origin\_group](#output\_cdn\_frontdoor\_origin\_group) | Cdn Frontdoor Origin Group |
 | <a name="output_cdn_frontdoor_profile"></a> [cdn\_frontdoor\_profile](#output\_cdn\_frontdoor\_profile) | Cdn Frontdoor Profile |
 | <a name="output_cdn_frontdoor_route"></a> [cdn\_frontdoor\_route](#output\_cdn\_frontdoor\_route) | Cdn Frontdoor Route |
-| <a name="output_cdn_endpoint"></a> [cdn\_endpoint](#output\_cdn\_endpoint) | Cdn Endpoint |
 | <a name="output_cdn_profile"></a> [cdn\_profile](#output\_cdn\_profile) | Cdn Profile |
 | <a name="output_cognitive_account"></a> [cognitive\_account](#output\_cognitive\_account) | Cognitive Account |
 | <a name="output_communication_service"></a> [communication\_service](#output\_communication\_service) | Communication Service |
@@ -172,9 +184,11 @@ No modules.
 | <a name="output_cosmosdb_cassandra"></a> [cosmosdb\_cassandra](#output\_cosmosdb\_cassandra) | Cosmosdb Cassandra |
 | <a name="output_cosmosdb_cassandra_cluster"></a> [cosmosdb\_cassandra\_cluster](#output\_cosmosdb\_cassandra\_cluster) | Cosmosdb Cassandra Cluster |
 | <a name="output_cosmosdb_cassandra_datacenter"></a> [cosmosdb\_cassandra\_datacenter](#output\_cosmosdb\_cassandra\_datacenter) | Cosmosdb Cassandra Datacenter |
-| <a name="output_comsosdb_gremlin"></a> [cosmosdb\_gremlin](#output\_cosmosdb\_grelmin) | Cosmosdb Gremlin |
+| <a name="output_cosmosdb_gremlin"></a> [cosmosdb\_gremlin](#output\_cosmosdb\_gremlin) | Cosmosdb Gremlin |
+| <a name="output_cosmosdb_mongodb"></a> [cosmosdb\_mongodb](#output\_cosmosdb\_mongodb) | Cosmosdb Mongodb |
+| <a name="output_cosmosdb_nosql"></a> [cosmosdb\_nosql](#output\_cosmosdb\_nosql) | Cosmosdb Nosql |
 | <a name="output_cosmosdb_postgres"></a> [cosmosdb\_postgres](#output\_cosmosdb\_postgres) | Cosmosdb Postgres |
-| <a name="output_cosmosdb_tables"></a> [cosmosdb\_tables](#output\_comsosdb\_tables) | Comsosdb Tables |
+| <a name="output_cosmosdb_tables"></a> [cosmosdb\_tables](#output\_cosmosdb\_tables) | Cosmosdb Tables |
 | <a name="output_custom_provider"></a> [custom\_provider](#output\_custom\_provider) | Custom Provider |
 | <a name="output_dashboard"></a> [dashboard](#output\_dashboard) | Dashboard |
 | <a name="output_dashboard_grafana"></a> [dashboard\_grafana](#output\_dashboard\_grafana) | Dashboard Grafana |
@@ -212,14 +226,14 @@ No modules.
 | <a name="output_dns_cname_record"></a> [dns\_cname\_record](#output\_dns\_cname\_record) | Dns Cname Record |
 | <a name="output_dns_mx_record"></a> [dns\_mx\_record](#output\_dns\_mx\_record) | Dns Mx Record |
 | <a name="output_dns_ns_record"></a> [dns\_ns\_record](#output\_dns\_ns\_record) | Dns Ns Record |
+| <a name="output_dns_private_resolver"></a> [dns\_private\_resolver](#output\_dns\_private\_resolver) | Dns Private Resolver |
 | <a name="output_dns_ptr_record"></a> [dns\_ptr\_record](#output\_dns\_ptr\_record) | Dns Ptr Record |
 | <a name="output_dns_txt_record"></a> [dns\_txt\_record](#output\_dns\_txt\_record) | Dns Txt Record |
-| <a name="output_dns_private_resolver"></a> [dns\_private\_resolver](#output\_dns\_private\_resolver) | Dns Private Resolver |
 | <a name="output_dns_zone"></a> [dns\_zone](#output\_dns\_zone) | Dns Zone |
 | <a name="output_eventgrid_domain"></a> [eventgrid\_domain](#output\_eventgrid\_domain) | Eventgrid Domain |
 | <a name="output_eventgrid_domain_topic"></a> [eventgrid\_domain\_topic](#output\_eventgrid\_domain\_topic) | Eventgrid Domain Topic |
-| <a name="output_eventgrid_namespace"></a> [eventgrid\_namespace](#output\_eventgrid\_namespace) | Eventgrid Namespace |
 | <a name="output_eventgrid_event_subscription"></a> [eventgrid\_event\_subscription](#output\_eventgrid\_event\_subscription) | Eventgrid Event Subscription |
+| <a name="output_eventgrid_namespace"></a> [eventgrid\_namespace](#output\_eventgrid\_namespace) | Eventgrid Namespace |
 | <a name="output_eventgrid_system_topic"></a> [eventgrid\_system\_topic](#output\_eventgrid\_system\_topic) | Eventgrid System Topic |
 | <a name="output_eventgrid_topic"></a> [eventgrid\_topic](#output\_eventgrid\_topic) | Eventgrid Topic |
 | <a name="output_eventhub"></a> [eventhub](#output\_eventhub) | Eventhub |
@@ -270,17 +284,18 @@ No modules.
 | <a name="output_lb_rule"></a> [lb\_rule](#output\_lb\_rule) | Lb Rule |
 | <a name="output_linux_virtual_machine"></a> [linux\_virtual\_machine](#output\_linux\_virtual\_machine) | Linux Virtual Machine |
 | <a name="output_linux_virtual_machine_scale_set"></a> [linux\_virtual\_machine\_scale\_set](#output\_linux\_virtual\_machine\_scale\_set) | Linux Virtual Machine Scale Set |
+| <a name="output_load_test"></a> [load\_test](#output\_load\_test) | Load Test |
 | <a name="output_local_network_gateway"></a> [local\_network\_gateway](#output\_local\_network\_gateway) | Local Network Gateway |
-| <a name="output_log_anlaytics_query_pack"></a> [log\_analytics\_query\_pack](#output\_log\_analytics\_query\_pack) | Log Analytics Query Pack |
+| <a name="output_log_analytics_query_pack"></a> [log\_analytics\_query\_pack](#output\_log\_analytics\_query\_pack) | Log Analytics Query Pack |
 | <a name="output_log_analytics_workspace"></a> [log\_analytics\_workspace](#output\_log\_analytics\_workspace) | Log Analytics Workspace |
 | <a name="output_logic_app_integration_account"></a> [logic\_app\_integration\_account](#output\_logic\_app\_integration\_account) | Logic App Integration Account |
 | <a name="output_logic_app_workflow"></a> [logic\_app\_workflow](#output\_logic\_app\_workflow) | Logic App Workflow |
-| <a name="output_machine_learning_workspace"></a> [machine\_learning\_workspace](#output\_machine\_learning\_workspace) | Machine Learning Workspace |
 | <a name="output_machine_learning_registry"></a> [machine\_learning\_registry](#output\_machine\_learning\_registry) | Machine Learning Registry |
+| <a name="output_machine_learning_workspace"></a> [machine\_learning\_workspace](#output\_machine\_learning\_workspace) | Machine Learning Workspace |
+| <a name="output_maintenance_configuration"></a> [maintenance\_configuration](#output\_maintenance\_configuration) | Maintenance Configuration |
 | <a name="output_managed_disk"></a> [managed\_disk](#output\_managed\_disk) | Managed Disk |
 | <a name="output_management_group"></a> [management\_group](#output\_management\_group) | Management Group |
 | <a name="output_maps_account"></a> [maps\_account](#output\_maps\_account) | Maps Account |
-| <a name="output_maintentance_configuration"></a> [maintenance\_configuration](#output\_maintenance\_configuration) | Maintenance Configuration |
 | <a name="output_mariadb_database"></a> [mariadb\_database](#output\_mariadb\_database) | Mariadb Database |
 | <a name="output_mariadb_firewall_rule"></a> [mariadb\_firewall\_rule](#output\_mariadb\_firewall\_rule) | Mariadb Firewall Rule |
 | <a name="output_mariadb_server"></a> [mariadb\_server](#output\_mariadb\_server) | Mariadb Server |
@@ -295,13 +310,13 @@ No modules.
 | <a name="output_mssql_database"></a> [mssql\_database](#output\_mssql\_database) | Mssql Database |
 | <a name="output_mssql_elasticpool"></a> [mssql\_elasticpool](#output\_mssql\_elasticpool) | Mssql Elasticpool |
 | <a name="output_mssql_job_agent"></a> [mssql\_job\_agent](#output\_mssql\_job\_agent) | Mssql Job Agent |
-| <a name="output_mssql_managed_instance"></a> [mssql\_managed\_instance](#output\_mssql\_managed\_instance) | Mssql Server Managed Instance |
+| <a name="output_mssql_managed_instance"></a> [mssql\_managed\_instance](#output\_mssql\_managed\_instance) | Mssql Managed Instance |
 | <a name="output_mssql_server"></a> [mssql\_server](#output\_mssql\_server) | Mssql Server |
 | <a name="output_mysql_database"></a> [mysql\_database](#output\_mysql\_database) | Mysql Database |
 | <a name="output_mysql_firewall_rule"></a> [mysql\_firewall\_rule](#output\_mysql\_firewall\_rule) | Mysql Firewall Rule |
 | <a name="output_mysql_server"></a> [mysql\_server](#output\_mysql\_server) | Mysql Server |
 | <a name="output_mysql_virtual_network_rule"></a> [mysql\_virtual\_network\_rule](#output\_mysql\_virtual\_network\_rule) | Mysql Virtual Network Rule |
-| <a name="output_nat_gateway"></a> [nat\_gateway](#output\_nat\_gateway) | NAT Gateway |
+| <a name="output_nat_gateway"></a> [nat\_gateway](#output\_nat\_gateway) | Nat Gateway |
 | <a name="output_network_ddos_protection_plan"></a> [network\_ddos\_protection\_plan](#output\_network\_ddos\_protection\_plan) | Network Ddos Protection Plan |
 | <a name="output_network_interface"></a> [network\_interface](#output\_network\_interface) | Network Interface |
 | <a name="output_network_manager"></a> [network\_manager](#output\_network\_manager) | Network Manager |
@@ -313,7 +328,7 @@ No modules.
 | <a name="output_notification_hub_authorization_rule"></a> [notification\_hub\_authorization\_rule](#output\_notification\_hub\_authorization\_rule) | Notification Hub Authorization Rule |
 | <a name="output_notification_hub_namespace"></a> [notification\_hub\_namespace](#output\_notification\_hub\_namespace) | Notification Hub Namespace |
 | <a name="output_point_to_site_vpn_gateway"></a> [point\_to\_site\_vpn\_gateway](#output\_point\_to\_site\_vpn\_gateway) | Point To Site Vpn Gateway |
-| <a name="output_policy_definition"></a> [policy\_definition](#output\_policy_definition) | Policy Definition |
+| <a name="output_policy_definition"></a> [policy\_definition](#output\_policy\_definition) | Policy Definition |
 | <a name="output_postgresql_database"></a> [postgresql\_database](#output\_postgresql\_database) | Postgresql Database |
 | <a name="output_postgresql_firewall_rule"></a> [postgresql\_firewall\_rule](#output\_postgresql\_firewall\_rule) | Postgresql Firewall Rule |
 | <a name="output_postgresql_server"></a> [postgresql\_server](#output\_postgresql\_server) | Postgresql Server |
@@ -368,6 +383,7 @@ No modules.
 | <a name="output_sql_firewall_rule"></a> [sql\_firewall\_rule](#output\_sql\_firewall\_rule) | Sql Firewall Rule |
 | <a name="output_sql_server"></a> [sql\_server](#output\_sql\_server) | Sql Server |
 | <a name="output_ssh_public_key"></a> [ssh\_public\_key](#output\_ssh\_public\_key) | Ssh Public Key |
+| <a name="output_static_web_app"></a> [static\_web\_app](#output\_static\_web\_app) | Static Web App |
 | <a name="output_storage_account"></a> [storage\_account](#output\_storage\_account) | Storage Account |
 | <a name="output_storage_blob"></a> [storage\_blob](#output\_storage\_blob) | Storage Blob |
 | <a name="output_storage_container"></a> [storage\_container](#output\_storage\_container) | Storage Container |
@@ -414,13 +430,12 @@ No modules.
 | <a name="output_virtual_network_peering"></a> [virtual\_network\_peering](#output\_virtual\_network\_peering) | Virtual Network Peering |
 | <a name="output_virtual_wan"></a> [virtual\_wan](#output\_virtual\_wan) | Virtual Wan |
 | <a name="output_vpn_gateway"></a> [vpn\_gateway](#output\_vpn\_gateway) | Vpn Gateway |
-| <a name="output_vpn_gateway_connection"></a> [vpn\_gateway\_connection](#output\_vpn\_gateway\_connection) | Vpn Gateway Connection  |
+| <a name="output_vpn_gateway_connection"></a> [vpn\_gateway\_connection](#output\_vpn\_gateway\_connection) | Vpn Gateway Connection |
 | <a name="output_vpn_site"></a> [vpn\_site](#output\_vpn\_site) | Vpn Site |
 | <a name="output_web_application_firewall_policy"></a> [web\_application\_firewall\_policy](#output\_web\_application\_firewall\_policy) | Web Application Firewall Policy |
 | <a name="output_web_application_firewall_policy_rule_group"></a> [web\_application\_firewall\_policy\_rule\_group](#output\_web\_application\_firewall\_policy\_rule\_group) | Web Application Firewall Policy Rule Group |
 | <a name="output_windows_virtual_machine"></a> [windows\_virtual\_machine](#output\_windows\_virtual\_machine) | Windows Virtual Machine |
 | <a name="output_windows_virtual_machine_scale_set"></a> [windows\_virtual\_machine\_scale\_set](#output\_windows\_virtual\_machine\_scale\_set) | Windows Virtual Machine Scale Set |
-| <a name="static_web_app"></a> [static\_web\_app](#output\_static_\_web\_app) | Static Web App |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 # Contributing Guidelines

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -50,3 +50,15 @@ output "everything" {
 output "validation_everything" {
   value = module.everything.validation
 }
+
+// Example 5
+
+module "disabled" {
+  source          = "../"
+  suffix          = ["su", "fix"]
+  unique-disabled = true
+}
+
+output "disabled" {
+  value = module.disabled.storage_account.name_unique
+}

--- a/main.tf
+++ b/main.tf
@@ -7,14 +7,28 @@ terraform {
   }
 }
 
+moved {
+  from = random_string.main
+  to   = random_string.main[0]
+}
+
 resource "random_string" "main" {
+  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+
   length  = 60
   special = false
   upper   = false
   numeric = var.unique-include-numbers
 }
 
+moved {
+  from = random_string.first_letter
+  to   = random_string.first_letter[0]
+}
+
 resource "random_string" "first_letter" {
+  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+
   length  = 1
   special = false
   upper   = false
@@ -25,20 +39,20 @@ resource "random_string" "first_letter" {
 
 locals {
   // adding a first letter to guarantee that you always start with a letter
-  random_safe_generation = join("", [random_string.first_letter.result, random_string.main.result])
-  random                 = substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
+  random_safe_generation = var.unique-seed == "" && !var.unique-disabled ? join("", [random_string.first_letter[0].result, random_string.main[0].result]) : ""
+  random                 = var.unique-disabled ? "" : substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
   prefix                 = join("-", var.prefix)
   prefix_safe            = lower(join("", var.prefix))
   suffix                 = join("-", var.suffix)
-  suffix_unique          = join("-", concat(var.suffix, [local.random]))
+  suffix_unique          = var.unique-disabled ? null : join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
-  suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
+  suffix_unique_safe     = var.unique-disabled ? null : lower(join("", concat(var.suffix, [local.random])))
   // Names based in the recomendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {
     analysis_services_server = {
       name        = substr(join("", compact([local.prefix_safe, "as", local.suffix_safe])), 0, 63)
-      name_unique = substr(join("", compact([local.prefix_safe, "as", local.suffix_unique_safe])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "as", local.suffix_unique_safe])), 0, 63)
       dashes      = false
       slug        = "as"
       min_length  = 3
@@ -48,7 +62,7 @@ locals {
     }
     api_management = {
       name        = substr(join("-", compact([local.prefix, "apim", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "apim", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "apim", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "apim"
       min_length  = 1
@@ -58,7 +72,7 @@ locals {
     }
     app_configuration = {
       name        = substr(join("-", compact([local.prefix, "appcg", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "appcg", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "appcg", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "appcg"
       min_length  = 5
@@ -68,7 +82,7 @@ locals {
     }
     app_service = {
       name        = substr(join("-", compact([local.prefix, "app", local.suffix])), 0, 60)
-      name_unique = substr(join("-", compact([local.prefix, "app", local.suffix_unique])), 0, 60)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "app", local.suffix_unique])), 0, 60)
       dashes      = true
       slug        = "app"
       min_length  = 2
@@ -78,7 +92,7 @@ locals {
     }
     app_service_environment = {
       name        = substr(join("-", compact([local.prefix, "ase", local.suffix])), 0, 40)
-      name_unique = substr(join("-", compact([local.prefix, "ase", local.suffix_unique])), 0, 40)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ase", local.suffix_unique])), 0, 40)
       dashes      = true
       slug        = "ase"
       min_length  = 1
@@ -88,7 +102,7 @@ locals {
     }
     app_service_plan = {
       name        = substr(join("-", compact([local.prefix, "plan", local.suffix])), 0, 40)
-      name_unique = substr(join("-", compact([local.prefix, "plan", local.suffix_unique])), 0, 40)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "plan", local.suffix_unique])), 0, 40)
       dashes      = true
       slug        = "plan"
       min_length  = 1
@@ -98,7 +112,7 @@ locals {
     }
     application_gateway = {
       name        = substr(join("-", compact([local.prefix, "agw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "agw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "agw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "agw"
       min_length  = 1
@@ -108,7 +122,7 @@ locals {
     }
     application_insights = {
       name        = substr(join("-", compact([local.prefix, "appi", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "appi", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "appi", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "appi"
       min_length  = 10
@@ -118,7 +132,7 @@ locals {
     }
     application_security_group = {
       name        = substr(join("-", compact([local.prefix, "asg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "asg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "asg"
       min_length  = 1
@@ -128,7 +142,7 @@ locals {
     }
     automation_account = {
       name        = substr(join("-", compact([local.prefix, "aa", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "aa", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aa", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "aa"
       min_length  = 6
@@ -138,7 +152,7 @@ locals {
     }
     automation_certificate = {
       name        = substr(join("-", compact([local.prefix, "aacert", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "aacert", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aacert", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "aacert"
       min_length  = 1
@@ -148,7 +162,7 @@ locals {
     }
     automation_credential = {
       name        = substr(join("-", compact([local.prefix, "aacred", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "aacred", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aacred", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "aacred"
       min_length  = 1
@@ -158,7 +172,7 @@ locals {
     }
     automation_runbook = {
       name        = substr(join("-", compact([local.prefix, "aacred", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "aacred", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aacred", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "aacred"
       min_length  = 1
@@ -168,7 +182,7 @@ locals {
     }
     automation_schedule = {
       name        = substr(join("-", compact([local.prefix, "aasched", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "aasched", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aasched", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "aasched"
       min_length  = 1
@@ -178,7 +192,7 @@ locals {
     }
     automation_variable = {
       name        = substr(join("-", compact([local.prefix, "aavar", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "aavar", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aavar", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "aavar"
       min_length  = 1
@@ -188,7 +202,7 @@ locals {
     }
     availability_set = {
       name        = substr(join("-", compact([local.prefix, "avail", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "avail", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "avail", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "avail"
       min_length  = 1
@@ -198,7 +212,7 @@ locals {
     }
     backup_policy_vm = {
       name        = substr(join("-", compact([local.prefix, "bkpol", local.suffix])), 0, 150)
-      name_unique = substr(join("-", compact([local.prefix, "bkpol", local.suffix_unique])), 0, 150)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "bkpol", local.suffix_unique])), 0, 150)
       dashes      = true
       slug        = "bkpol"
       min_length  = 3
@@ -208,7 +222,7 @@ locals {
     }
     bastion_host = {
       name        = substr(join("-", compact([local.prefix, "snap", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "snap", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "snap", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "snap"
       min_length  = 1
@@ -218,7 +232,7 @@ locals {
     }
     batch_account = {
       name        = substr(join("", compact([local.prefix_safe, "ba", local.suffix_safe])), 0, 24)
-      name_unique = substr(join("", compact([local.prefix_safe, "ba", local.suffix_unique_safe])), 0, 24)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "ba", local.suffix_unique_safe])), 0, 24)
       dashes      = false
       slug        = "ba"
       min_length  = 3
@@ -228,7 +242,7 @@ locals {
     }
     batch_application = {
       name        = substr(join("-", compact([local.prefix, "baapp", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "baapp", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "baapp", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "baapp"
       min_length  = 1
@@ -238,7 +252,7 @@ locals {
     }
     batch_certificate = {
       name        = substr(join("-", compact([local.prefix, "bacert", local.suffix])), 0, 45)
-      name_unique = substr(join("-", compact([local.prefix, "bacert", local.suffix_unique])), 0, 45)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "bacert", local.suffix_unique])), 0, 45)
       dashes      = true
       slug        = "bacert"
       min_length  = 5
@@ -248,7 +262,7 @@ locals {
     }
     batch_pool = {
       name        = substr(join("-", compact([local.prefix, "bapool", local.suffix])), 0, 24)
-      name_unique = substr(join("-", compact([local.prefix, "bapool", local.suffix_unique])), 0, 24)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "bapool", local.suffix_unique])), 0, 24)
       dashes      = true
       slug        = "bapool"
       min_length  = 3
@@ -258,7 +272,7 @@ locals {
     }
     bot_channel_directline = {
       name        = substr(join("-", compact([local.prefix, "botline", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "botline", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "botline", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "botline"
       min_length  = 2
@@ -268,7 +282,7 @@ locals {
     }
     bot_channel_email = {
       name        = substr(join("-", compact([local.prefix, "botmail", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "botmail", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "botmail", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "botmail"
       min_length  = 2
@@ -278,7 +292,7 @@ locals {
     }
     bot_channel_ms_teams = {
       name        = substr(join("-", compact([local.prefix, "botteams", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "botteams", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "botteams", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "botteams"
       min_length  = 2
@@ -288,7 +302,7 @@ locals {
     }
     bot_channel_slack = {
       name        = substr(join("-", compact([local.prefix, "botslack", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "botslack", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "botslack", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "botslack"
       min_length  = 2
@@ -298,7 +312,7 @@ locals {
     }
     bot_channels_registration = {
       name        = substr(join("-", compact([local.prefix, "botchan", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "botchan", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "botchan", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "botchan"
       min_length  = 2
@@ -308,7 +322,7 @@ locals {
     }
     bot_connection = {
       name        = substr(join("-", compact([local.prefix, "botcon", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "botcon", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "botcon", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "botcon"
       min_length  = 2
@@ -318,7 +332,7 @@ locals {
     }
     bot_web_app = {
       name        = substr(join("-", compact([local.prefix, "bot", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "bot", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "bot", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "bot"
       min_length  = 2
@@ -328,7 +342,7 @@ locals {
     }
     cdn_endpoint = {
       name        = substr(join("-", compact([local.prefix, "cdn", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "cdn", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cdn", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "cdn"
       min_length  = 1
@@ -338,7 +352,7 @@ locals {
     }
     cdn_frontdoor_endpoint = {
       name        = substr(join("-", compact([local.prefix, "fde", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "fde", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fde", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "fde"
       min_length  = 1
@@ -348,7 +362,7 @@ locals {
     }
     cdn_frontdoor_origin = {
       name        = substr(join("-", compact([local.prefix, "cdno", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "cdno", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cdno", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "cdno"
       min_length  = 1
@@ -358,7 +372,7 @@ locals {
     }
     cdn_frontdoor_origin_group = {
       name        = substr(join("-", compact([local.prefix, "cdnog", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "cdnog", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cdnog", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "cdnog"
       min_length  = 1
@@ -368,7 +382,7 @@ locals {
     }
     cdn_frontdoor_profile = {
       name        = substr(join("-", compact([local.prefix, "afd", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "afd", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "afd", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "afd"
       min_length  = 5
@@ -378,7 +392,7 @@ locals {
     }
     cdn_frontdoor_route = {
       name        = substr(join("-", compact([local.prefix, "cdnr", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "cdnr", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cdnr", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "cdnr"
       min_length  = 1
@@ -388,7 +402,7 @@ locals {
     }
     cdn_profile = {
       name        = substr(join("-", compact([local.prefix, "cdnprof", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "cdnprof", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cdnprof", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "cdnprof"
       min_length  = 1
@@ -398,7 +412,7 @@ locals {
     }
     cognitive_account = {
       name        = substr(join("-", compact([local.prefix, "cog", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "cog", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cog", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "cog"
       min_length  = 2
@@ -408,7 +422,7 @@ locals {
     }
     communication_service = {
       name        = substr(join("-", compact([local.prefix, "acs", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "acs", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "acs", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "acs"
       min_length  = 1
@@ -418,7 +432,7 @@ locals {
     }
     container_app = {
       name        = substr(join("-", compact([local.prefix, "ca", local.suffix])), 0, 32)
-      name_unique = substr(join("-", compact([local.prefix, "ca", local.suffix_unique])), 0, 32)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ca", local.suffix_unique])), 0, 32)
       dashes      = true
       slug        = "ca"
       min_length  = 1
@@ -428,7 +442,7 @@ locals {
     }
     container_app_environment = {
       name        = substr(join("-", compact([local.prefix, "cae", local.suffix])), 0, 60)
-      name_unique = substr(join("-", compact([local.prefix, "cae", local.suffix_unique])), 0, 60)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cae", local.suffix_unique])), 0, 60)
       dashes      = true
       slug        = "cae"
       min_length  = 1
@@ -438,7 +452,7 @@ locals {
     }
     container_app_job = {
       name        = substr(join("-", compact([local.prefix, "caj", local.suffix])), 0, 32)
-      name_unique = substr(join("-", compact([local.prefix, "caj", local.suffix_unique])), 0, 32)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "caj", local.suffix_unique])), 0, 32)
       dashes      = true
       slug        = "caj"
       min_length  = 2
@@ -448,7 +462,7 @@ locals {
     }
     container_group = {
       name        = substr(join("-", compact([local.prefix, "cg", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "cg", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cg", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "cg"
       min_length  = 1
@@ -458,7 +472,7 @@ locals {
     }
     container_registry = {
       name        = substr(join("", compact([local.prefix_safe, "acr", local.suffix_safe])), 0, 63)
-      name_unique = substr(join("", compact([local.prefix_safe, "acr", local.suffix_unique_safe])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "acr", local.suffix_unique_safe])), 0, 63)
       dashes      = false
       slug        = "acr"
       min_length  = 1
@@ -468,7 +482,7 @@ locals {
     }
     container_registry_webhook = {
       name        = substr(join("", compact([local.prefix_safe, "crwh", local.suffix_safe])), 0, 50)
-      name_unique = substr(join("", compact([local.prefix_safe, "crwh", local.suffix_unique_safe])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "crwh", local.suffix_unique_safe])), 0, 50)
       dashes      = false
       slug        = "crwh"
       min_length  = 1
@@ -478,7 +492,7 @@ locals {
     }
     cosmosdb_account = {
       name        = substr(join("-", compact([local.prefix, "cosmos", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "cosmos", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cosmos", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "cosmos"
       min_length  = 1
@@ -488,7 +502,7 @@ locals {
     }
     cosmosdb_cassandra = {
       name        = substr(join("-", compact([local.prefix, "coscas", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "coscas", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "coscas", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "coscas"
       min_length  = 3
@@ -498,7 +512,7 @@ locals {
     }
     cosmosdb_cassandra_cluster = {
       name        = substr(join("-", compact([local.prefix, "mcc", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "mcc", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mcc", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "mcc"
       min_length  = 1
@@ -508,7 +522,7 @@ locals {
     }
     cosmosdb_cassandra_datacenter = {
       name        = substr(join("-", compact([local.prefix, "mcdc", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "mcdc", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mcdc", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "mcdc"
       min_length  = 1
@@ -518,7 +532,7 @@ locals {
     }
     cosmosdb_gremlin = {
       name        = substr(join("-", compact([local.prefix, "cosgrm", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "cosgrm", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cosgrm", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "cosgrm"
       min_length  = 3
@@ -528,7 +542,7 @@ locals {
     }
     cosmosdb_mongodb = {
       name        = substr(join("-", compact([local.prefix, "cosmon", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "cosmon", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cosmon", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "cosmon"
       min_length  = 3
@@ -538,7 +552,7 @@ locals {
     }
     cosmosdb_nosql = {
       name        = substr(join("-", compact([local.prefix, "cosno", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "cosno", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cosno", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "cosno"
       min_length  = 3
@@ -548,7 +562,7 @@ locals {
     }
     cosmosdb_postgres = {
       name        = substr(join("-", compact([local.prefix, "cospos", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "cospos", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "cospos", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "cospos"
       min_length  = 1
@@ -558,7 +572,7 @@ locals {
     }
     cosmosdb_tables = {
       name        = substr(join("-", compact([local.prefix, "costab", local.suffix])), 0, 44)
-      name_unique = substr(join("-", compact([local.prefix, "costab", local.suffix_unique])), 0, 44)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "costab", local.suffix_unique])), 0, 44)
       dashes      = true
       slug        = "costab"
       min_length  = 3
@@ -568,7 +582,7 @@ locals {
     }
     custom_provider = {
       name        = substr(join("-", compact([local.prefix, "prov", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "prov", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "prov", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "prov"
       min_length  = 3
@@ -578,7 +592,7 @@ locals {
     }
     dashboard = {
       name        = substr(join("-", compact([local.prefix, "dsb", local.suffix])), 0, 160)
-      name_unique = substr(join("-", compact([local.prefix, "dsb", local.suffix_unique])), 0, 160)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dsb", local.suffix_unique])), 0, 160)
       dashes      = true
       slug        = "dsb"
       min_length  = 3
@@ -588,7 +602,7 @@ locals {
     }
     dashboard_grafana = {
       name        = substr(join("-", compact([local.prefix, "amg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "amg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "amg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "amg"
       min_length  = 1
@@ -598,7 +612,7 @@ locals {
     }
     data_factory = {
       name        = substr(join("-", compact([local.prefix, "adf", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "adf", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adf", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "adf"
       min_length  = 3
@@ -608,7 +622,7 @@ locals {
     }
     data_factory_dataset_mysql = {
       name        = substr(join("-", compact([local.prefix, "adfmysql", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfmysql", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfmysql", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfmysql"
       min_length  = 1
@@ -618,7 +632,7 @@ locals {
     }
     data_factory_dataset_postgresql = {
       name        = substr(join("-", compact([local.prefix, "adfpsql", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfpsql", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfpsql", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfpsql"
       min_length  = 1
@@ -628,7 +642,7 @@ locals {
     }
     data_factory_dataset_sql_server_table = {
       name        = substr(join("-", compact([local.prefix, "adfmssql", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfmssql", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfmssql", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfmssql"
       min_length  = 1
@@ -638,7 +652,7 @@ locals {
     }
     data_factory_integration_runtime_managed = {
       name        = substr(join("-", compact([local.prefix, "adfir", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "adfir", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfir", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "adfir"
       min_length  = 3
@@ -648,7 +662,7 @@ locals {
     }
     data_factory_linked_service_data_lake_storage_gen2 = {
       name        = substr(join("-", compact([local.prefix, "adfsvst", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfsvst", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfsvst", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfsvst"
       min_length  = 1
@@ -658,7 +672,7 @@ locals {
     }
     data_factory_linked_service_key_vault = {
       name        = substr(join("-", compact([local.prefix, "adfsvkv", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfsvkv", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfsvkv", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfsvkv"
       min_length  = 1
@@ -668,7 +682,7 @@ locals {
     }
     data_factory_linked_service_mysql = {
       name        = substr(join("-", compact([local.prefix, "adfsvmysql", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfsvmysql", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfsvmysql", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfsvmysql"
       min_length  = 1
@@ -678,7 +692,7 @@ locals {
     }
     data_factory_linked_service_postgresql = {
       name        = substr(join("-", compact([local.prefix, "adfsvpsql", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfsvpsql", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfsvpsql", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfsvpsql"
       min_length  = 1
@@ -688,7 +702,7 @@ locals {
     }
     data_factory_linked_service_sql_server = {
       name        = substr(join("-", compact([local.prefix, "adfsvmssql", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfsvmssql", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfsvmssql", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfsvmssql"
       min_length  = 1
@@ -698,7 +712,7 @@ locals {
     }
     data_factory_pipeline = {
       name        = substr(join("-", compact([local.prefix, "adfpl", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adfpl", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adfpl", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adfpl"
       min_length  = 1
@@ -708,7 +722,7 @@ locals {
     }
     data_factory_trigger_schedule = {
       name        = substr(join("-", compact([local.prefix, "adftg", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "adftg", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "adftg", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "adftg"
       min_length  = 1
@@ -718,7 +732,7 @@ locals {
     }
     data_lake_analytics_account = {
       name        = substr(join("", compact([local.prefix_safe, "dla", local.suffix_safe])), 0, 24)
-      name_unique = substr(join("", compact([local.prefix_safe, "dla", local.suffix_unique_safe])), 0, 24)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "dla", local.suffix_unique_safe])), 0, 24)
       dashes      = false
       slug        = "dla"
       min_length  = 3
@@ -728,7 +742,7 @@ locals {
     }
     data_lake_analytics_firewall_rule = {
       name        = substr(join("-", compact([local.prefix, "dlfw", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "dlfw", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dlfw", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "dlfw"
       min_length  = 3
@@ -738,7 +752,7 @@ locals {
     }
     data_lake_store = {
       name        = substr(join("", compact([local.prefix_safe, "dls", local.suffix_safe])), 0, 24)
-      name_unique = substr(join("", compact([local.prefix_safe, "dls", local.suffix_unique_safe])), 0, 24)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "dls", local.suffix_unique_safe])), 0, 24)
       dashes      = false
       slug        = "dls"
       min_length  = 3
@@ -748,7 +762,7 @@ locals {
     }
     data_lake_store_firewall_rule = {
       name        = substr(join("-", compact([local.prefix, "dlsfw", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "dlsfw", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dlsfw", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "dlsfw"
       min_length  = 3
@@ -758,7 +772,7 @@ locals {
     }
     data_protection_backup_vault = {
       name        = substr(join("-", compact([local.prefix, "bvault", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "bvault", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "bvault", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "bvault"
       min_length  = 2
@@ -768,7 +782,7 @@ locals {
     }
     database_migration_project = {
       name        = substr(join("-", compact([local.prefix, "migr", local.suffix])), 0, 57)
-      name_unique = substr(join("-", compact([local.prefix, "migr", local.suffix_unique])), 0, 57)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "migr", local.suffix_unique])), 0, 57)
       dashes      = true
       slug        = "migr"
       min_length  = 2
@@ -778,7 +792,7 @@ locals {
     }
     database_migration_service = {
       name        = substr(join("-", compact([local.prefix, "dms", local.suffix])), 0, 62)
-      name_unique = substr(join("-", compact([local.prefix, "dms", local.suffix_unique])), 0, 62)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dms", local.suffix_unique])), 0, 62)
       dashes      = true
       slug        = "dms"
       min_length  = 2
@@ -788,7 +802,7 @@ locals {
     }
     databricks_access_connector = {
       name        = substr(join("-", compact([local.prefix, "dbac", local.suffix])), 0, 30)
-      name_unique = substr(join("-", compact([local.prefix, "dbac", local.suffix_unique])), 0, 30)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dbac", local.suffix_unique])), 0, 30)
       dashes      = true
       slug        = "dbac"
       min_length  = 3
@@ -798,7 +812,7 @@ locals {
     }
     databricks_cluster = {
       name        = substr(join("-", compact([local.prefix, "dbc", local.suffix])), 0, 30)
-      name_unique = substr(join("-", compact([local.prefix, "dbc", local.suffix_unique])), 0, 30)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dbc", local.suffix_unique])), 0, 30)
       dashes      = true
       slug        = "dbc"
       min_length  = 3
@@ -808,7 +822,7 @@ locals {
     }
     databricks_high_concurrency_cluster = {
       name        = substr(join("-", compact([local.prefix, "dbhcc", local.suffix])), 0, 30)
-      name_unique = substr(join("-", compact([local.prefix, "dbhcc", local.suffix_unique])), 0, 30)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dbhcc", local.suffix_unique])), 0, 30)
       dashes      = true
       slug        = "dbhcc"
       min_length  = 3
@@ -818,7 +832,7 @@ locals {
     }
     databricks_standard_cluster = {
       name        = substr(join("-", compact([local.prefix, "dbsc", local.suffix])), 0, 30)
-      name_unique = substr(join("-", compact([local.prefix, "dbsc", local.suffix_unique])), 0, 30)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dbsc", local.suffix_unique])), 0, 30)
       dashes      = true
       slug        = "dbsc"
       min_length  = 3
@@ -828,7 +842,7 @@ locals {
     }
     databricks_workspace = {
       name        = substr(join("-", compact([local.prefix, "dbw", local.suffix])), 0, 30)
-      name_unique = substr(join("-", compact([local.prefix, "dbw", local.suffix_unique])), 0, 30)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dbw", local.suffix_unique])), 0, 30)
       dashes      = true
       slug        = "dbw"
       min_length  = 3
@@ -838,7 +852,7 @@ locals {
     }
     dev_test_lab = {
       name        = substr(join("-", compact([local.prefix, "lab", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "lab", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "lab", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "lab"
       min_length  = 1
@@ -848,7 +862,7 @@ locals {
     }
     dev_test_linux_virtual_machine = {
       name        = substr(join("-", compact([local.prefix, "labvm", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "labvm", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "labvm", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "labvm"
       min_length  = 1
@@ -858,7 +872,7 @@ locals {
     }
     dev_test_windows_virtual_machine = {
       name        = substr(join("-", compact([local.prefix, "labvm", local.suffix])), 0, 15)
-      name_unique = substr(join("-", compact([local.prefix, "labvm", local.suffix_unique])), 0, 15)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "labvm", local.suffix_unique])), 0, 15)
       dashes      = true
       slug        = "labvm"
       min_length  = 1
@@ -868,7 +882,7 @@ locals {
     }
     disk_encryption_set = {
       name        = substr(join("-", compact([local.prefix, "des", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "des", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "des", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "des"
       min_length  = 1
@@ -878,7 +892,7 @@ locals {
     }
     dns_a_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -888,7 +902,7 @@ locals {
     }
     dns_aaaa_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -898,7 +912,7 @@ locals {
     }
     dns_caa_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -908,7 +922,7 @@ locals {
     }
     dns_cname_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -918,7 +932,7 @@ locals {
     }
     dns_mx_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -928,7 +942,7 @@ locals {
     }
     dns_ns_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -938,7 +952,7 @@ locals {
     }
     dns_private_resolver = {
       name        = substr(join("-", compact([local.prefix, "dnspr", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnspr", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnspr", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnspr"
       min_length  = 1
@@ -948,7 +962,7 @@ locals {
     }
     dns_ptr_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -958,7 +972,7 @@ locals {
     }
     dns_txt_record = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -968,7 +982,7 @@ locals {
     }
     dns_zone = {
       name        = substr(join("-", compact([local.prefix, "dns", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "dns", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dns", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "dns"
       min_length  = 1
@@ -978,7 +992,7 @@ locals {
     }
     eventgrid_domain = {
       name        = substr(join("-", compact([local.prefix, "egd", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "egd", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "egd", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "egd"
       min_length  = 3
@@ -988,7 +1002,7 @@ locals {
     }
     eventgrid_domain_topic = {
       name        = substr(join("-", compact([local.prefix, "egdt", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "egdt", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "egdt", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "egdt"
       min_length  = 3
@@ -998,7 +1012,7 @@ locals {
     }
     eventgrid_event_subscription = {
       name        = substr(join("-", compact([local.prefix, "egs", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "egs", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "egs", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "egs"
       min_length  = 3
@@ -1008,7 +1022,7 @@ locals {
     }
     eventgrid_namespace = {
       name        = substr(join("-", compact([local.prefix, "evgns", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "evgns", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "evgns", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "evgns"
       min_length  = 3
@@ -1018,7 +1032,7 @@ locals {
     }
     eventgrid_system_topic = {
       name        = substr(join("-", compact([local.prefix, "egst", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "egst", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "egst", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "egst"
       min_length  = 3
@@ -1028,7 +1042,7 @@ locals {
     }
     eventgrid_topic = {
       name        = substr(join("-", compact([local.prefix, "egt", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "egt", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "egt", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "egt"
       min_length  = 3
@@ -1038,7 +1052,7 @@ locals {
     }
     eventhub = {
       name        = substr(join("-", compact([local.prefix, "evh", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "evh", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "evh", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "evh"
       min_length  = 1
@@ -1048,7 +1062,7 @@ locals {
     }
     eventhub_authorization_rule = {
       name        = substr(join("-", compact([local.prefix, "ehar", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "ehar", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ehar", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "ehar"
       min_length  = 1
@@ -1058,7 +1072,7 @@ locals {
     }
     eventhub_cluster = {
       name        = substr(join("-", compact([local.prefix, "evhcl", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "evhcl", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "evhcl", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "evhcl"
       min_length  = 6
@@ -1068,7 +1082,7 @@ locals {
     }
     eventhub_consumer_group = {
       name        = substr(join("-", compact([local.prefix, "ehcg", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "ehcg", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ehcg", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "ehcg"
       min_length  = 1
@@ -1078,7 +1092,7 @@ locals {
     }
     eventhub_namespace = {
       name        = substr(join("-", compact([local.prefix, "ehn", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "ehn", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ehn", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "ehn"
       min_length  = 1
@@ -1088,7 +1102,7 @@ locals {
     }
     eventhub_namespace_authorization_rule = {
       name        = substr(join("-", compact([local.prefix, "ehnar", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "ehnar", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ehnar", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "ehnar"
       min_length  = 1
@@ -1098,7 +1112,7 @@ locals {
     }
     eventhub_namespace_disaster_recovery_config = {
       name        = substr(join("-", compact([local.prefix, "ehdr", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "ehdr", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ehdr", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "ehdr"
       min_length  = 1
@@ -1108,7 +1122,7 @@ locals {
     }
     express_route_circuit = {
       name        = substr(join("-", compact([local.prefix, "erc", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "erc", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "erc", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "erc"
       min_length  = 1
@@ -1118,7 +1132,7 @@ locals {
     }
     express_route_gateway = {
       name        = substr(join("-", compact([local.prefix, "ergw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "ergw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ergw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "ergw"
       min_length  = 1
@@ -1128,7 +1142,7 @@ locals {
     }
     fabric_capacity = {
       name        = substr(join("", compact([local.prefix_safe, "fc", local.suffix_safe])), 0, 63)
-      name_unique = substr(join("", compact([local.prefix_safe, "fc", local.suffix_unique_safe])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "fc", local.suffix_unique_safe])), 0, 63)
       dashes      = false
       slug        = "fc"
       min_length  = 3
@@ -1138,7 +1152,7 @@ locals {
     }
     firewall = {
       name        = substr(join("-", compact([local.prefix, "fw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fw"
       min_length  = 1
@@ -1148,7 +1162,7 @@ locals {
     }
     firewall_application_rule_collection = {
       name        = substr(join("-", compact([local.prefix, "fwapp", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fwapp", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fwapp", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fwapp"
       min_length  = 1
@@ -1158,7 +1172,7 @@ locals {
     }
     firewall_ip_configuration = {
       name        = substr(join("-", compact([local.prefix, "fwipconf", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fwipconf", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fwipconf", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fwipconf"
       min_length  = 1
@@ -1168,7 +1182,7 @@ locals {
     }
     firewall_nat_rule_collection = {
       name        = substr(join("-", compact([local.prefix, "fwnatrc", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fwnatrc", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fwnatrc", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fwnatrc"
       min_length  = 1
@@ -1178,7 +1192,7 @@ locals {
     }
     firewall_network_rule_collection = {
       name        = substr(join("-", compact([local.prefix, "fwnetrc", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fwnetrc", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fwnetrc", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fwnetrc"
       min_length  = 1
@@ -1188,7 +1202,7 @@ locals {
     }
     firewall_policy = {
       name        = substr(join("-", compact([local.prefix, "afwp", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "afwp", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "afwp", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "afwp"
       min_length  = 1
@@ -1198,7 +1212,7 @@ locals {
     }
     firewall_policy_rule_collection_group = {
       name        = substr(join("-", compact([local.prefix, "fwprcg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fwprcg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fwprcg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fwprcg"
       min_length  = 1
@@ -1208,7 +1222,7 @@ locals {
     }
     frontdoor = {
       name        = substr(join("-", compact([local.prefix, "fd", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "fd", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fd", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "fd"
       min_length  = 5
@@ -1218,7 +1232,7 @@ locals {
     }
     frontdoor_firewall_policy = {
       name        = substr(join("-", compact([local.prefix, "fdfw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "fdfw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "fdfw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "fdfw"
       min_length  = 1
@@ -1228,7 +1242,7 @@ locals {
     }
     function_app = {
       name        = substr(join("-", compact([local.prefix, "func", local.suffix])), 0, 60)
-      name_unique = substr(join("-", compact([local.prefix, "func", local.suffix_unique])), 0, 60)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "func", local.suffix_unique])), 0, 60)
       dashes      = true
       slug        = "func"
       min_length  = 2
@@ -1238,7 +1252,7 @@ locals {
     }
     hdinsight_hadoop_cluster = {
       name        = substr(join("-", compact([local.prefix, "hadoop", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "hadoop", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "hadoop", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "hadoop"
       min_length  = 3
@@ -1248,7 +1262,7 @@ locals {
     }
     hdinsight_hbase_cluster = {
       name        = substr(join("-", compact([local.prefix, "hbase", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "hbase", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "hbase", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "hbase"
       min_length  = 3
@@ -1258,7 +1272,7 @@ locals {
     }
     hdinsight_interactive_query_cluster = {
       name        = substr(join("-", compact([local.prefix, "iqr", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "iqr", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "iqr", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "iqr"
       min_length  = 3
@@ -1268,7 +1282,7 @@ locals {
     }
     hdinsight_kafka_cluster = {
       name        = substr(join("-", compact([local.prefix, "kafka", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "kafka", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kafka", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "kafka"
       min_length  = 3
@@ -1278,7 +1292,7 @@ locals {
     }
     hdinsight_ml_services_cluster = {
       name        = substr(join("-", compact([local.prefix, "mls", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "mls", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mls", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "mls"
       min_length  = 3
@@ -1288,7 +1302,7 @@ locals {
     }
     hdinsight_rserver_cluster = {
       name        = substr(join("-", compact([local.prefix, "rsv", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "rsv", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rsv", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "rsv"
       min_length  = 3
@@ -1298,7 +1312,7 @@ locals {
     }
     hdinsight_spark_cluster = {
       name        = substr(join("-", compact([local.prefix, "spark", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "spark", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "spark", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "spark"
       min_length  = 3
@@ -1308,7 +1322,7 @@ locals {
     }
     hdinsight_storm_cluster = {
       name        = substr(join("-", compact([local.prefix, "storm", local.suffix])), 0, 59)
-      name_unique = substr(join("-", compact([local.prefix, "storm", local.suffix_unique])), 0, 59)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "storm", local.suffix_unique])), 0, 59)
       dashes      = true
       slug        = "storm"
       min_length  = 3
@@ -1318,7 +1332,7 @@ locals {
     }
     image = {
       name        = substr(join("-", compact([local.prefix, "img", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "img", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "img", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "img"
       min_length  = 1
@@ -1328,7 +1342,7 @@ locals {
     }
     iotcentral_application = {
       name        = substr(join("-", compact([local.prefix, "iotapp", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "iotapp", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "iotapp", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "iotapp"
       min_length  = 2
@@ -1338,7 +1352,7 @@ locals {
     }
     iothub = {
       name        = substr(join("-", compact([local.prefix, "iot", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "iot", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "iot", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "iot"
       min_length  = 3
@@ -1348,7 +1362,7 @@ locals {
     }
     iothub_consumer_group = {
       name        = substr(join("-", compact([local.prefix, "iotcg", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "iotcg", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "iotcg", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "iotcg"
       min_length  = 1
@@ -1358,7 +1372,7 @@ locals {
     }
     iothub_dps = {
       name        = substr(join("-", compact([local.prefix, "dps", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "dps", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dps", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "dps"
       min_length  = 3
@@ -1368,7 +1382,7 @@ locals {
     }
     iothub_dps_certificate = {
       name        = substr(join("-", compact([local.prefix, "dpscert", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "dpscert", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dpscert", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "dpscert"
       min_length  = 1
@@ -1378,7 +1392,7 @@ locals {
     }
     ip_group = {
       name        = substr(join("-", compact([local.prefix, "ipg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "ipg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ipg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "ipg"
       min_length  = 1
@@ -1388,7 +1402,7 @@ locals {
     }
     key_vault = {
       name        = substr(join("-", compact([local.prefix, "kv", local.suffix])), 0, 24)
-      name_unique = substr(join("-", compact([local.prefix, "kv", local.suffix_unique])), 0, 24)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kv", local.suffix_unique])), 0, 24)
       dashes      = true
       slug        = "kv"
       min_length  = 3
@@ -1398,7 +1412,7 @@ locals {
     }
     key_vault_certificate = {
       name        = substr(join("-", compact([local.prefix, "kvc", local.suffix])), 0, 127)
-      name_unique = substr(join("-", compact([local.prefix, "kvc", local.suffix_unique])), 0, 127)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kvc", local.suffix_unique])), 0, 127)
       dashes      = true
       slug        = "kvc"
       min_length  = 1
@@ -1408,7 +1422,7 @@ locals {
     }
     key_vault_key = {
       name        = substr(join("-", compact([local.prefix, "kvk", local.suffix])), 0, 127)
-      name_unique = substr(join("-", compact([local.prefix, "kvk", local.suffix_unique])), 0, 127)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kvk", local.suffix_unique])), 0, 127)
       dashes      = true
       slug        = "kvk"
       min_length  = 1
@@ -1418,7 +1432,7 @@ locals {
     }
     key_vault_secret = {
       name        = substr(join("-", compact([local.prefix, "kvs", local.suffix])), 0, 127)
-      name_unique = substr(join("-", compact([local.prefix, "kvs", local.suffix_unique])), 0, 127)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kvs", local.suffix_unique])), 0, 127)
       dashes      = true
       slug        = "kvs"
       min_length  = 1
@@ -1428,7 +1442,7 @@ locals {
     }
     kubernetes_cluster = {
       name        = substr(join("-", compact([local.prefix, "aks", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "aks", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aks", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "aks"
       min_length  = 1
@@ -1438,7 +1452,7 @@ locals {
     }
     kusto_cluster = {
       name        = substr(join("", compact([local.prefix_safe, "kc", local.suffix_safe])), 0, 22)
-      name_unique = substr(join("", compact([local.prefix_safe, "kc", local.suffix_unique_safe])), 0, 22)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "kc", local.suffix_unique_safe])), 0, 22)
       dashes      = false
       slug        = "kc"
       min_length  = 4
@@ -1448,7 +1462,7 @@ locals {
     }
     kusto_database = {
       name        = substr(join("-", compact([local.prefix, "kdb", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "kdb", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kdb", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "kdb"
       min_length  = 1
@@ -1458,7 +1472,7 @@ locals {
     }
     kusto_eventhub_data_connection = {
       name        = substr(join("-", compact([local.prefix, "kehc", local.suffix])), 0, 40)
-      name_unique = substr(join("-", compact([local.prefix, "kehc", local.suffix_unique])), 0, 40)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "kehc", local.suffix_unique])), 0, 40)
       dashes      = true
       slug        = "kehc"
       min_length  = 1
@@ -1468,7 +1482,7 @@ locals {
     }
     lb = {
       name        = substr(join("-", compact([local.prefix, "lb", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "lb", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "lb", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "lb"
       min_length  = 1
@@ -1478,7 +1492,7 @@ locals {
     }
     lb_nat_rule = {
       name        = substr(join("-", compact([local.prefix, "lbnatrl", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "lbnatrl", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "lbnatrl", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "lbnatrl"
       min_length  = 1
@@ -1488,7 +1502,7 @@ locals {
     }
     lb_rule = {
       name        = substr(join("-", compact([local.prefix, "rule", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "rule", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rule", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "rule"
       min_length  = 1
@@ -1498,7 +1512,7 @@ locals {
     }
     linux_virtual_machine = {
       name        = substr(join("-", compact([local.prefix, "vm", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "vm", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vm", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "vm"
       min_length  = 1
@@ -1508,7 +1522,7 @@ locals {
     }
     linux_virtual_machine_scale_set = {
       name        = substr(join("-", compact([local.prefix, "vmss", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "vmss", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vmss", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "vmss"
       min_length  = 1
@@ -1518,7 +1532,7 @@ locals {
     }
     load_test = {
       name        = substr(join("-", compact([local.prefix, "lt", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "lt", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "lt", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "lt"
       min_length  = 1
@@ -1528,7 +1542,7 @@ locals {
     }
     local_network_gateway = {
       name        = substr(join("-", compact([local.prefix, "lgw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "lgw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "lgw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "lgw"
       min_length  = 1
@@ -1538,7 +1552,7 @@ locals {
     }
     log_analytics_query_pack = {
       name        = substr(join("-", compact([local.prefix, "pack", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "pack", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pack", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "pack"
       min_length  = 4
@@ -1548,7 +1562,7 @@ locals {
     }
     log_analytics_workspace = {
       name        = substr(join("-", compact([local.prefix, "log", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "log", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "log", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "log"
       min_length  = 4
@@ -1558,7 +1572,7 @@ locals {
     }
     logic_app_integration_account = {
       name        = substr(join("-", compact([local.prefix, "ia", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "ia", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ia", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "ia"
       min_length  = 1
@@ -1568,7 +1582,7 @@ locals {
     }
     logic_app_workflow = {
       name        = substr(join("-", compact([local.prefix, "logic", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "logic", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "logic", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "logic"
       min_length  = 1
@@ -1578,7 +1592,7 @@ locals {
     }
     machine_learning_registry = {
       name        = substr(join("-", compact([local.prefix, "mlr", local.suffix])), 0, 33)
-      name_unique = substr(join("-", compact([local.prefix, "mlr", local.suffix_unique])), 0, 33)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mlr", local.suffix_unique])), 0, 33)
       dashes      = true
       slug        = "mlr"
       min_length  = 3
@@ -1588,7 +1602,7 @@ locals {
     }
     machine_learning_workspace = {
       name        = substr(join("-", compact([local.prefix, "mlw", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "mlw", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mlw", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "mlw"
       min_length  = 1
@@ -1598,7 +1612,7 @@ locals {
     }
     maintenance_configuration = {
       name        = substr(join("-", compact([local.prefix, "mc", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "mc", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mc", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "mc"
       min_length  = 1
@@ -1608,7 +1622,7 @@ locals {
     }
     managed_disk = {
       name        = substr(join("-", compact([local.prefix, "dsk", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "dsk", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dsk", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "dsk"
       min_length  = 1
@@ -1618,7 +1632,7 @@ locals {
     }
     management_group = {
       name        = substr(join("-", compact([local.prefix, "mg", local.suffix])), 0, 90)
-      name_unique = substr(join("-", compact([local.prefix, "mg", local.suffix_unique])), 0, 90)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mg", local.suffix_unique])), 0, 90)
       dashes      = true
       slug        = "mg"
       min_length  = 1
@@ -1628,7 +1642,7 @@ locals {
     }
     maps_account = {
       name        = substr(join("-", compact([local.prefix, "map", local.suffix])), 0, 98)
-      name_unique = substr(join("-", compact([local.prefix, "map", local.suffix_unique])), 0, 98)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "map", local.suffix_unique])), 0, 98)
       dashes      = true
       slug        = "map"
       min_length  = 1
@@ -1638,7 +1652,7 @@ locals {
     }
     mariadb_database = {
       name        = substr(join("-", compact([local.prefix, "mariadb", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "mariadb", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mariadb", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "mariadb"
       min_length  = 1
@@ -1648,7 +1662,7 @@ locals {
     }
     mariadb_firewall_rule = {
       name        = substr(join("-", compact([local.prefix, "mariafw", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "mariafw", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mariafw", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "mariafw"
       min_length  = 1
@@ -1658,7 +1672,7 @@ locals {
     }
     mariadb_server = {
       name        = substr(join("-", compact([local.prefix, "maria", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "maria", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "maria", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "maria"
       min_length  = 3
@@ -1668,7 +1682,7 @@ locals {
     }
     mariadb_virtual_network_rule = {
       name        = substr(join("-", compact([local.prefix, "mariavn", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "mariavn", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mariavn", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "mariavn"
       min_length  = 1
@@ -1678,7 +1692,7 @@ locals {
     }
     monitor_action_group = {
       name        = substr(join("-", compact([local.prefix, "mag", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "mag", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mag", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "mag"
       min_length  = 1
@@ -1688,7 +1702,7 @@ locals {
     }
     monitor_alert_processing_rule_action_group = {
       name        = substr(join("-", compact([local.prefix, "apr", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "apr", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "apr", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "apr"
       min_length  = 1
@@ -1698,7 +1712,7 @@ locals {
     }
     monitor_autoscale_setting = {
       name        = substr(join("-", compact([local.prefix, "mas", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "mas", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mas", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "mas"
       min_length  = 1
@@ -1708,7 +1722,7 @@ locals {
     }
     monitor_data_collection_endpoint = {
       name        = substr(join("-", compact([local.prefix, "dce", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "dce", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dce", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "dce"
       min_length  = 1
@@ -1718,7 +1732,7 @@ locals {
     }
     monitor_data_collection_rule = {
       name        = substr(join("-", compact([local.prefix, "dcr", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "dcr", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dcr", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "dcr"
       min_length  = 1
@@ -1728,7 +1742,7 @@ locals {
     }
     monitor_diagnostic_setting = {
       name        = substr(join("-", compact([local.prefix, "mds", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "mds", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mds", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "mds"
       min_length  = 1
@@ -1738,7 +1752,7 @@ locals {
     }
     monitor_scheduled_query_rules_alert = {
       name        = substr(join("-", compact([local.prefix, "msqa", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "msqa", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "msqa", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "msqa"
       min_length  = 1
@@ -1748,7 +1762,7 @@ locals {
     }
     mssql_database = {
       name        = substr(join("-", compact([local.prefix, "sqldb", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "sqldb", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqldb", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "sqldb"
       min_length  = 1
@@ -1758,7 +1772,7 @@ locals {
     }
     mssql_elasticpool = {
       name        = substr(join("-", compact([local.prefix, "sqlep", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "sqlep", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqlep", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "sqlep"
       min_length  = 1
@@ -1768,7 +1782,7 @@ locals {
     }
     mssql_job_agent = {
       name        = substr(join("-", compact([local.prefix, "sqlja", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "sqlja", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqlja", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "sqlja"
       min_length  = 1
@@ -1778,7 +1792,7 @@ locals {
     }
     mssql_managed_instance = {
       name        = substr(join("-", compact([local.prefix, "sqlmi", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sqlmi", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqlmi", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sqlmi"
       min_length  = 1
@@ -1788,7 +1802,7 @@ locals {
     }
     mssql_server = {
       name        = substr(join("-", compact([local.prefix, "sql", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sql"
       min_length  = 1
@@ -1798,7 +1812,7 @@ locals {
     }
     mysql_database = {
       name        = substr(join("-", compact([local.prefix, "mysqldb", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "mysqldb", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mysqldb", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "mysqldb"
       min_length  = 1
@@ -1808,7 +1822,7 @@ locals {
     }
     mysql_firewall_rule = {
       name        = substr(join("-", compact([local.prefix, "mysqlfw", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "mysqlfw", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mysqlfw", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "mysqlfw"
       min_length  = 1
@@ -1818,7 +1832,7 @@ locals {
     }
     mysql_server = {
       name        = substr(join("-", compact([local.prefix, "mysql", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "mysql", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mysql", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "mysql"
       min_length  = 3
@@ -1828,7 +1842,7 @@ locals {
     }
     mysql_virtual_network_rule = {
       name        = substr(join("-", compact([local.prefix, "mysqlvn", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "mysqlvn", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "mysqlvn", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "mysqlvn"
       min_length  = 1
@@ -1838,7 +1852,7 @@ locals {
     }
     nat_gateway = {
       name        = substr(join("-", compact([local.prefix, "ng", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "ng", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ng", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "ng"
       min_length  = 1
@@ -1848,7 +1862,7 @@ locals {
     }
     network_ddos_protection_plan = {
       name        = substr(join("-", compact([local.prefix, "ddospp", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "ddospp", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ddospp", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "ddospp"
       min_length  = 1
@@ -1858,7 +1872,7 @@ locals {
     }
     network_interface = {
       name        = substr(join("-", compact([local.prefix, "nic", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "nic", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "nic", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "nic"
       min_length  = 1
@@ -1868,7 +1882,7 @@ locals {
     }
     network_manager = {
       name        = substr(join("-", compact([local.prefix, "vnm", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vnm", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vnm", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vnm"
       min_length  = 1
@@ -1878,7 +1892,7 @@ locals {
     }
     network_security_group = {
       name        = substr(join("-", compact([local.prefix, "nsg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "nsg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "nsg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "nsg"
       min_length  = 1
@@ -1888,7 +1902,7 @@ locals {
     }
     network_security_group_rule = {
       name        = substr(join("-", compact([local.prefix, "nsgr", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "nsgr", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "nsgr", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "nsgr"
       min_length  = 1
@@ -1898,7 +1912,7 @@ locals {
     }
     network_security_rule = {
       name        = substr(join("-", compact([local.prefix, "nsgr", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "nsgr", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "nsgr", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "nsgr"
       min_length  = 1
@@ -1908,7 +1922,7 @@ locals {
     }
     network_watcher = {
       name        = substr(join("-", compact([local.prefix, "nw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "nw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "nw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "nw"
       min_length  = 1
@@ -1918,7 +1932,7 @@ locals {
     }
     notification_hub = {
       name        = substr(join("-", compact([local.prefix, "nh", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "nh", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "nh", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "nh"
       min_length  = 1
@@ -1928,7 +1942,7 @@ locals {
     }
     notification_hub_authorization_rule = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 256)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 256)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 256)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -1938,7 +1952,7 @@ locals {
     }
     notification_hub_namespace = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 6
@@ -1948,7 +1962,7 @@ locals {
     }
     point_to_site_vpn_gateway = {
       name        = substr(join("-", compact([local.prefix, "vpngw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vpngw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vpngw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vpngw"
       min_length  = 1
@@ -1958,7 +1972,7 @@ locals {
     }
     policy_definition = {
       name        = substr(join("-", compact([local.prefix, "pdef", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "pdef", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdef", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "pdef"
       min_length  = 1
@@ -1968,7 +1982,7 @@ locals {
     }
     postgresql_database = {
       name        = substr(join("-", compact([local.prefix, "psqldb", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "psqldb", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "psqldb", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "psqldb"
       min_length  = 1
@@ -1978,7 +1992,7 @@ locals {
     }
     postgresql_firewall_rule = {
       name        = substr(join("-", compact([local.prefix, "psqlfw", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "psqlfw", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "psqlfw", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "psqlfw"
       min_length  = 1
@@ -1988,7 +2002,7 @@ locals {
     }
     postgresql_server = {
       name        = substr(join("-", compact([local.prefix, "psql", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "psql", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "psql", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "psql"
       min_length  = 3
@@ -1998,7 +2012,7 @@ locals {
     }
     postgresql_virtual_network_rule = {
       name        = substr(join("-", compact([local.prefix, "psqlvn", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "psqlvn", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "psqlvn", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "psqlvn"
       min_length  = 1
@@ -2008,7 +2022,7 @@ locals {
     }
     powerbi_embedded = {
       name        = substr(join("-", compact([local.prefix, "pbi", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "pbi", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pbi", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "pbi"
       min_length  = 3
@@ -2018,7 +2032,7 @@ locals {
     }
     private_dns_a_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2028,7 +2042,7 @@ locals {
     }
     private_dns_aaaa_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2038,7 +2052,7 @@ locals {
     }
     private_dns_cname_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2048,7 +2062,7 @@ locals {
     }
     private_dns_mx_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2058,7 +2072,7 @@ locals {
     }
     private_dns_ptr_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2068,7 +2082,7 @@ locals {
     }
     private_dns_srv_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2078,7 +2092,7 @@ locals {
     }
     private_dns_txt_record = {
       name        = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnsrec", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnsrec"
       min_length  = 1
@@ -2088,7 +2102,7 @@ locals {
     }
     private_dns_zone = {
       name        = substr(join("-", compact([local.prefix, "pdns", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "pdns", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdns", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "pdns"
       min_length  = 1
@@ -2098,7 +2112,7 @@ locals {
     }
     private_dns_zone_group = {
       name        = substr(join("-", compact([local.prefix, "pdnszg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pdnszg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pdnszg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pdnszg"
       min_length  = 1
@@ -2108,7 +2122,7 @@ locals {
     }
     private_endpoint = {
       name        = substr(join("-", compact([local.prefix, "pe", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pe", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pe", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pe"
       min_length  = 1
@@ -2118,7 +2132,7 @@ locals {
     }
     private_link_service = {
       name        = substr(join("-", compact([local.prefix, "pls", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pls", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pls", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pls"
       min_length  = 1
@@ -2128,7 +2142,7 @@ locals {
     }
     private_service_connection = {
       name        = substr(join("-", compact([local.prefix, "psc", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "psc", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "psc", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "psc"
       min_length  = 1
@@ -2138,7 +2152,7 @@ locals {
     }
     proximity_placement_group = {
       name        = substr(join("-", compact([local.prefix, "ppg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "ppg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ppg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "ppg"
       min_length  = 1
@@ -2148,7 +2162,7 @@ locals {
     }
     public_ip = {
       name        = substr(join("-", compact([local.prefix, "pip", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pip", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pip", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pip"
       min_length  = 1
@@ -2158,7 +2172,7 @@ locals {
     }
     public_ip_prefix = {
       name        = substr(join("-", compact([local.prefix, "pippf", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "pippf", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pippf", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "pippf"
       min_length  = 1
@@ -2168,7 +2182,7 @@ locals {
     }
     purview_account = {
       name        = substr(join("-", compact([local.prefix, "pview", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "pview", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "pview", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "pview"
       min_length  = 3
@@ -2178,7 +2192,7 @@ locals {
     }
     recovery_services_vault = {
       name        = substr(join("-", compact([local.prefix, "rsv", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "rsv", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rsv", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "rsv"
       min_length  = 2
@@ -2188,7 +2202,7 @@ locals {
     }
     redhat_openshift_cluster = {
       name        = substr(join("-", compact([local.prefix, "aro", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "aro", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "aro", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "aro"
       min_length  = 1
@@ -2198,7 +2212,7 @@ locals {
     }
     redis_cache = {
       name        = substr(join("-", compact([local.prefix, "redis", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "redis", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "redis", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "redis"
       min_length  = 1
@@ -2208,7 +2222,7 @@ locals {
     }
     redis_firewall_rule = {
       name        = substr(join("", compact([local.prefix_safe, "redisfw", local.suffix_safe])), 0, 256)
-      name_unique = substr(join("", compact([local.prefix_safe, "redisfw", local.suffix_unique_safe])), 0, 256)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "redisfw", local.suffix_unique_safe])), 0, 256)
       dashes      = false
       slug        = "redisfw"
       min_length  = 1
@@ -2218,7 +2232,7 @@ locals {
     }
     relay_hybrid_connection = {
       name        = substr(join("-", compact([local.prefix, "rlhc", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "rlhc", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rlhc", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "rlhc"
       min_length  = 1
@@ -2228,7 +2242,7 @@ locals {
     }
     relay_namespace = {
       name        = substr(join("-", compact([local.prefix, "rln", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "rln", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rln", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "rln"
       min_length  = 6
@@ -2238,7 +2252,7 @@ locals {
     }
     resource_group = {
       name        = substr(join("-", compact([local.prefix, "rg", local.suffix])), 0, 90)
-      name_unique = substr(join("-", compact([local.prefix, "rg", local.suffix_unique])), 0, 90)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rg", local.suffix_unique])), 0, 90)
       dashes      = true
       slug        = "rg"
       min_length  = 1
@@ -2248,7 +2262,7 @@ locals {
     }
     resource_group_template_deployment = {
       name        = substr(join("-", compact([local.prefix, "ts", local.suffix])), 0, 90)
-      name_unique = substr(join("-", compact([local.prefix, "ts", local.suffix_unique])), 0, 90)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ts", local.suffix_unique])), 0, 90)
       dashes      = true
       slug        = "ts"
       min_length  = 1
@@ -2258,7 +2272,7 @@ locals {
     }
     role_assignment = {
       name        = substr(join("-", compact([local.prefix, "ra", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "ra", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "ra", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "ra"
       min_length  = 1
@@ -2268,7 +2282,7 @@ locals {
     }
     role_definition = {
       name        = substr(join("-", compact([local.prefix, "rd", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "rd", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rd", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "rd"
       min_length  = 1
@@ -2278,7 +2292,7 @@ locals {
     }
     route = {
       name        = substr(join("-", compact([local.prefix, "rt", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "rt", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rt", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "rt"
       min_length  = 1
@@ -2288,7 +2302,7 @@ locals {
     }
     route_filter = {
       name        = substr(join("-", compact([local.prefix, "rf", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "rf", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rf", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "rf"
       min_length  = 1
@@ -2298,7 +2312,7 @@ locals {
     }
     route_server = {
       name        = substr(join("-", compact([local.prefix, "rtserv", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "rtserv", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rtserv", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "rtserv"
       min_length  = 1
@@ -2308,7 +2322,7 @@ locals {
     }
     route_table = {
       name        = substr(join("-", compact([local.prefix, "route", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "route", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "route", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "route"
       min_length  = 1
@@ -2318,7 +2332,7 @@ locals {
     }
     search_service = {
       name        = substr(join("-", compact([local.prefix, "srch", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "srch", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "srch", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "srch"
       min_length  = 2
@@ -2328,7 +2342,7 @@ locals {
     }
     service_fabric_cluster = {
       name        = substr(join("-", compact([local.prefix, "sf", local.suffix])), 0, 23)
-      name_unique = substr(join("-", compact([local.prefix, "sf", local.suffix_unique])), 0, 23)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sf", local.suffix_unique])), 0, 23)
       dashes      = true
       slug        = "sf"
       min_length  = 4
@@ -2338,7 +2352,7 @@ locals {
     }
     servicebus_namespace = {
       name        = substr(join("-", compact([local.prefix, "sb", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "sb", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sb", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "sb"
       min_length  = 6
@@ -2348,7 +2362,7 @@ locals {
     }
     servicebus_namespace_authorization_rule = {
       name        = substr(join("-", compact([local.prefix, "sbar", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "sbar", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sbar", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "sbar"
       min_length  = 1
@@ -2358,7 +2372,7 @@ locals {
     }
     servicebus_queue = {
       name        = substr(join("-", compact([local.prefix, "sbq", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "sbq", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sbq", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "sbq"
       min_length  = 1
@@ -2368,7 +2382,7 @@ locals {
     }
     servicebus_queue_authorization_rule = {
       name        = substr(join("-", compact([local.prefix, "sbqar", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "sbqar", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sbqar", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "sbqar"
       min_length  = 1
@@ -2378,7 +2392,7 @@ locals {
     }
     servicebus_subscription = {
       name        = substr(join("-", compact([local.prefix, "sbs", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "sbs", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sbs", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "sbs"
       min_length  = 1
@@ -2388,7 +2402,7 @@ locals {
     }
     servicebus_subscription_rule = {
       name        = substr(join("-", compact([local.prefix, "sbsr", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "sbsr", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sbsr", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "sbsr"
       min_length  = 1
@@ -2398,7 +2412,7 @@ locals {
     }
     servicebus_topic = {
       name        = substr(join("-", compact([local.prefix, "sbt", local.suffix])), 0, 260)
-      name_unique = substr(join("-", compact([local.prefix, "sbt", local.suffix_unique])), 0, 260)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sbt", local.suffix_unique])), 0, 260)
       dashes      = true
       slug        = "sbt"
       min_length  = 1
@@ -2408,7 +2422,7 @@ locals {
     }
     servicebus_topic_authorization_rule = {
       name        = substr(join("-", compact([local.prefix, "dnsrec", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "dnsrec", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "dnsrec"
       min_length  = 1
@@ -2418,7 +2432,7 @@ locals {
     }
     shared_image = {
       name        = substr(join("-", compact([local.prefix, "si", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "si", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "si", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "si"
       min_length  = 1
@@ -2428,7 +2442,7 @@ locals {
     }
     shared_image_gallery = {
       name        = substr(join("", compact([local.prefix_safe, "sig", local.suffix_safe])), 0, 80)
-      name_unique = substr(join("", compact([local.prefix_safe, "sig", local.suffix_unique_safe])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "sig", local.suffix_unique_safe])), 0, 80)
       dashes      = false
       slug        = "sig"
       min_length  = 1
@@ -2438,7 +2452,7 @@ locals {
     }
     signalr_service = {
       name        = substr(join("-", compact([local.prefix, "sgnlr", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sgnlr", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sgnlr", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sgnlr"
       min_length  = 3
@@ -2448,7 +2462,7 @@ locals {
     }
     snapshots = {
       name        = substr(join("-", compact([local.prefix, "snap", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "snap", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "snap", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "snap"
       min_length  = 1
@@ -2458,7 +2472,7 @@ locals {
     }
     sql_elasticpool = {
       name        = substr(join("-", compact([local.prefix, "sqlep", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "sqlep", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqlep", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "sqlep"
       min_length  = 1
@@ -2468,7 +2482,7 @@ locals {
     }
     sql_failover_group = {
       name        = substr(join("-", compact([local.prefix, "sqlfg", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sqlfg", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqlfg", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sqlfg"
       min_length  = 1
@@ -2478,7 +2492,7 @@ locals {
     }
     sql_firewall_rule = {
       name        = substr(join("-", compact([local.prefix, "sqlfw", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "sqlfw", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sqlfw", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "sqlfw"
       min_length  = 1
@@ -2488,7 +2502,7 @@ locals {
     }
     sql_server = {
       name        = substr(join("-", compact([local.prefix, "sql", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sql", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sql"
       min_length  = 1
@@ -2498,7 +2512,7 @@ locals {
     }
     ssh_public_key = {
       name        = substr(join("-", compact([local.prefix, "sshkey", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "sshkey", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sshkey", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "sshkey"
       min_length  = 1
@@ -2508,7 +2522,7 @@ locals {
     }
     static_web_app = {
       name        = substr(join("-", compact([local.prefix, "stapp", local.suffix])), 0, 40)
-      name_unique = substr(join("-", compact([local.prefix, "stapp", local.suffix_unique])), 0, 40)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "stapp", local.suffix_unique])), 0, 40)
       dashes      = true
       slug        = "stapp"
       min_length  = 1
@@ -2518,7 +2532,7 @@ locals {
     }
     storage_account = {
       name        = substr(join("", compact([local.prefix_safe, "st", local.suffix_safe])), 0, 24)
-      name_unique = substr(join("", compact([local.prefix_safe, "st", local.suffix_unique_safe])), 0, 24)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "st", local.suffix_unique_safe])), 0, 24)
       dashes      = false
       slug        = "st"
       min_length  = 3
@@ -2528,7 +2542,7 @@ locals {
     }
     storage_blob = {
       name        = substr(join("-", compact([local.prefix, "blob", local.suffix])), 0, 1024)
-      name_unique = substr(join("-", compact([local.prefix, "blob", local.suffix_unique])), 0, 1024)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "blob", local.suffix_unique])), 0, 1024)
       dashes      = true
       slug        = "blob"
       min_length  = 1
@@ -2538,7 +2552,7 @@ locals {
     }
     storage_container = {
       name        = substr(join("-", compact([local.prefix, "stct", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "stct", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "stct", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "stct"
       min_length  = 3
@@ -2548,7 +2562,7 @@ locals {
     }
     storage_data_lake_gen2_filesystem = {
       name        = substr(join("-", compact([local.prefix, "stdl", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "stdl", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "stdl", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "stdl"
       min_length  = 3
@@ -2558,7 +2572,7 @@ locals {
     }
     storage_queue = {
       name        = substr(join("-", compact([local.prefix, "stq", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "stq", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "stq", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "stq"
       min_length  = 3
@@ -2568,7 +2582,7 @@ locals {
     }
     storage_share = {
       name        = substr(join("-", compact([local.prefix, "sts", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sts", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sts", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sts"
       min_length  = 3
@@ -2578,7 +2592,7 @@ locals {
     }
     storage_share_directory = {
       name        = substr(join("-", compact([local.prefix, "sts", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "sts", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "sts", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "sts"
       min_length  = 3
@@ -2588,7 +2602,7 @@ locals {
     }
     storage_table = {
       name        = substr(join("-", compact([local.prefix, "stt", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "stt", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "stt", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "stt"
       min_length  = 3
@@ -2598,7 +2612,7 @@ locals {
     }
     stream_analytics_function_javascript_udf = {
       name        = substr(join("-", compact([local.prefix, "asafunc", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asafunc", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asafunc", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asafunc"
       min_length  = 3
@@ -2608,7 +2622,7 @@ locals {
     }
     stream_analytics_job = {
       name        = substr(join("-", compact([local.prefix, "asa", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asa", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asa", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asa"
       min_length  = 3
@@ -2618,7 +2632,7 @@ locals {
     }
     stream_analytics_output_blob = {
       name        = substr(join("-", compact([local.prefix, "asaoblob", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaoblob", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaoblob", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaoblob"
       min_length  = 3
@@ -2628,7 +2642,7 @@ locals {
     }
     stream_analytics_output_eventhub = {
       name        = substr(join("-", compact([local.prefix, "asaoeh", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaoeh", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaoeh", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaoeh"
       min_length  = 3
@@ -2638,7 +2652,7 @@ locals {
     }
     stream_analytics_output_mssql = {
       name        = substr(join("-", compact([local.prefix, "asaomssql", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaomssql", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaomssql", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaomssql"
       min_length  = 3
@@ -2648,7 +2662,7 @@ locals {
     }
     stream_analytics_output_servicebus_queue = {
       name        = substr(join("-", compact([local.prefix, "asaosbq", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaosbq", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaosbq", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaosbq"
       min_length  = 3
@@ -2658,7 +2672,7 @@ locals {
     }
     stream_analytics_output_servicebus_topic = {
       name        = substr(join("-", compact([local.prefix, "asaosbt", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaosbt", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaosbt", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaosbt"
       min_length  = 3
@@ -2668,7 +2682,7 @@ locals {
     }
     stream_analytics_reference_input_blob = {
       name        = substr(join("-", compact([local.prefix, "asarblob", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asarblob", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asarblob", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asarblob"
       min_length  = 3
@@ -2678,7 +2692,7 @@ locals {
     }
     stream_analytics_stream_input_blob = {
       name        = substr(join("-", compact([local.prefix, "asaiblob", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaiblob", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaiblob", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaiblob"
       min_length  = 3
@@ -2688,7 +2702,7 @@ locals {
     }
     stream_analytics_stream_input_eventhub = {
       name        = substr(join("-", compact([local.prefix, "asaieh", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaieh", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaieh", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaieh"
       min_length  = 3
@@ -2698,7 +2712,7 @@ locals {
     }
     stream_analytics_stream_input_iothub = {
       name        = substr(join("-", compact([local.prefix, "asaiiot", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "asaiiot", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "asaiiot", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "asaiiot"
       min_length  = 3
@@ -2708,7 +2722,7 @@ locals {
     }
     subnet = {
       name        = substr(join("-", compact([local.prefix, "snet", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "snet", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "snet", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "snet"
       min_length  = 1
@@ -2718,7 +2732,7 @@ locals {
     }
     subnet_service_endpoint_storage_policy = {
       name        = substr(join("-", compact([local.prefix, "se", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "se", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "se", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "se"
       min_length  = 1
@@ -2728,7 +2742,7 @@ locals {
     }
     synapse_private_link_hub = {
       name        = substr(join("-", compact([local.prefix, "synplh", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "synplh", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "synplh", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "synplh"
       min_length  = 1
@@ -2738,7 +2752,7 @@ locals {
     }
     synapse_spark_pool = {
       name        = substr(join("", compact([local.prefix_safe, "synsp", local.suffix_safe])), 0, 32)
-      name_unique = substr(join("", compact([local.prefix_safe, "synsp", local.suffix_unique_safe])), 0, 32)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "synsp", local.suffix_unique_safe])), 0, 32)
       dashes      = false
       slug        = "synsp"
       min_length  = 3
@@ -2748,7 +2762,7 @@ locals {
     }
     synapse_sql_pool = {
       name        = substr(join("", compact([local.prefix_safe, "syndp", local.suffix_safe])), 0, 60)
-      name_unique = substr(join("", compact([local.prefix_safe, "syndp", local.suffix_unique_safe])), 0, 60)
+      name_unique = var.unique-disabled ? null : substr(join("", compact([local.prefix_safe, "syndp", local.suffix_unique_safe])), 0, 60)
       dashes      = false
       slug        = "syndp"
       min_length  = 1
@@ -2758,7 +2772,7 @@ locals {
     }
     synapse_workspace = {
       name        = substr(join("-", compact([local.prefix, "synw", local.suffix])), 0, 50)
-      name_unique = substr(join("-", compact([local.prefix, "synw", local.suffix_unique])), 0, 50)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "synw", local.suffix_unique])), 0, 50)
       dashes      = true
       slug        = "synw"
       min_length  = 1
@@ -2768,7 +2782,7 @@ locals {
     }
     template_deployment = {
       name        = substr(join("-", compact([local.prefix, "deploy", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "deploy", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "deploy", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "deploy"
       min_length  = 1
@@ -2778,7 +2792,7 @@ locals {
     }
     traffic_manager_profile = {
       name        = substr(join("-", compact([local.prefix, "traf", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "traf", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "traf", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "traf"
       min_length  = 1
@@ -2788,7 +2802,7 @@ locals {
     }
     user_assigned_identity = {
       name        = substr(join("-", compact([local.prefix, "uai", local.suffix])), 0, 128)
-      name_unique = substr(join("-", compact([local.prefix, "uai", local.suffix_unique])), 0, 128)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "uai", local.suffix_unique])), 0, 128)
       dashes      = true
       slug        = "uai"
       min_length  = 3
@@ -2798,7 +2812,7 @@ locals {
     }
     virtual_desktop_application_group = {
       name        = substr(join("-", compact([local.prefix, "vdag", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "vdag", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vdag", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "vdag"
       min_length  = 3
@@ -2808,7 +2822,7 @@ locals {
     }
     virtual_desktop_host_pool = {
       name        = substr(join("-", compact([local.prefix, "vdpool", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "vdpool", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vdpool", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "vdpool"
       min_length  = 3
@@ -2818,7 +2832,7 @@ locals {
     }
     virtual_desktop_scaling_plan = {
       name        = substr(join("-", compact([local.prefix, "vdscaling", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "vdscaling", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vdscaling", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "vdscaling"
       min_length  = 3
@@ -2828,7 +2842,7 @@ locals {
     }
     virtual_desktop_workspace = {
       name        = substr(join("-", compact([local.prefix, "vdws", local.suffix])), 0, 63)
-      name_unique = substr(join("-", compact([local.prefix, "vdws", local.suffix_unique])), 0, 63)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vdws", local.suffix_unique])), 0, 63)
       dashes      = true
       slug        = "vdws"
       min_length  = 3
@@ -2838,7 +2852,7 @@ locals {
     }
     virtual_hub = {
       name        = substr(join("-", compact([local.prefix, "vhub", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vhub", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vhub", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vhub"
       min_length  = 1
@@ -2848,7 +2862,7 @@ locals {
     }
     virtual_machine = {
       name        = substr(join("-", compact([local.prefix, "vm", local.suffix])), 0, 15)
-      name_unique = substr(join("-", compact([local.prefix, "vm", local.suffix_unique])), 0, 15)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vm", local.suffix_unique])), 0, 15)
       dashes      = true
       slug        = "vm"
       min_length  = 1
@@ -2858,7 +2872,7 @@ locals {
     }
     virtual_machine_extension = {
       name        = substr(join("-", compact([local.prefix, "vmx", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vmx", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vmx", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vmx"
       min_length  = 1
@@ -2868,7 +2882,7 @@ locals {
     }
     virtual_machine_restore_point_collection = {
       name        = substr(join("-", compact([local.prefix, "rpc", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "rpc", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "rpc", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "rpc"
       min_length  = 1
@@ -2878,7 +2892,7 @@ locals {
     }
     virtual_machine_scale_set = {
       name        = substr(join("-", compact([local.prefix, "vmss", local.suffix])), 0, 15)
-      name_unique = substr(join("-", compact([local.prefix, "vmss", local.suffix_unique])), 0, 15)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vmss", local.suffix_unique])), 0, 15)
       dashes      = true
       slug        = "vmss"
       min_length  = 1
@@ -2888,7 +2902,7 @@ locals {
     }
     virtual_machine_scale_set_extension = {
       name        = substr(join("-", compact([local.prefix, "vmssx", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vmssx", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vmssx", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vmssx"
       min_length  = 1
@@ -2898,7 +2912,7 @@ locals {
     }
     virtual_network = {
       name        = substr(join("-", compact([local.prefix, "vnet", local.suffix])), 0, 64)
-      name_unique = substr(join("-", compact([local.prefix, "vnet", local.suffix_unique])), 0, 64)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vnet", local.suffix_unique])), 0, 64)
       dashes      = true
       slug        = "vnet"
       min_length  = 2
@@ -2908,7 +2922,7 @@ locals {
     }
     virtual_network_gateway = {
       name        = substr(join("-", compact([local.prefix, "vgw", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vgw", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vgw", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vgw"
       min_length  = 1
@@ -2918,7 +2932,7 @@ locals {
     }
     virtual_network_gateway_connection = {
       name        = substr(join("-", compact([local.prefix, "vcn", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vcn", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vcn", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vcn"
       min_length  = 1
@@ -2928,7 +2942,7 @@ locals {
     }
     virtual_network_peering = {
       name        = substr(join("-", compact([local.prefix, "vpeer", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vpeer", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vpeer", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vpeer"
       min_length  = 1
@@ -2938,7 +2952,7 @@ locals {
     }
     virtual_wan = {
       name        = substr(join("-", compact([local.prefix, "vwan", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vwan", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vwan", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vwan"
       min_length  = 1
@@ -2948,7 +2962,7 @@ locals {
     }
     vpn_gateway = {
       name        = substr(join("-", compact([local.prefix, "vpng", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vpng", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vpng", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vpng"
       min_length  = 1
@@ -2958,7 +2972,7 @@ locals {
     }
     vpn_gateway_connection = {
       name        = substr(join("-", compact([local.prefix, "vcn", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vcn", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vcn", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vcn"
       min_length  = 1
@@ -2968,7 +2982,7 @@ locals {
     }
     vpn_site = {
       name        = substr(join("-", compact([local.prefix, "vst", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "vst", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vst", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "vst"
       min_length  = 1
@@ -2978,7 +2992,7 @@ locals {
     }
     web_application_firewall_policy = {
       name        = substr(join("-", compact([local.prefix, "waf", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "waf", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "waf", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "waf"
       min_length  = 1
@@ -2988,7 +3002,7 @@ locals {
     }
     web_application_firewall_policy_rule_group = {
       name        = substr(join("-", compact([local.prefix, "wafrg", local.suffix])), 0, 80)
-      name_unique = substr(join("-", compact([local.prefix, "wafrg", local.suffix_unique])), 0, 80)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "wafrg", local.suffix_unique])), 0, 80)
       dashes      = true
       slug        = "wafrg"
       min_length  = 1
@@ -2998,7 +3012,7 @@ locals {
     }
     windows_virtual_machine = {
       name        = substr(join("-", compact([local.prefix, "vm", local.suffix])), 0, 15)
-      name_unique = substr(join("-", compact([local.prefix, "vm", local.suffix_unique])), 0, 15)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vm", local.suffix_unique])), 0, 15)
       dashes      = true
       slug        = "vm"
       min_length  = 1
@@ -3008,7 +3022,7 @@ locals {
     }
     windows_virtual_machine_scale_set = {
       name        = substr(join("-", compact([local.prefix, "vmss", local.suffix])), 0, 15)
-      name_unique = substr(join("-", compact([local.prefix, "vmss", local.suffix_unique])), 0, 15)
+      name_unique = var.unique-disabled ? null : substr(join("-", compact([local.prefix, "vmss", local.suffix_unique])), 0, 15)
       dashes      = true
       slug        = "vmss"
       min_length  = 1
@@ -3020,1195 +3034,1195 @@ locals {
   validation = {
     analysis_services_server = {
       valid_name        = length(regexall(local.az.analysis_services_server.regex, local.az.analysis_services_server.name)) > 0 && length(local.az.analysis_services_server.name) > local.az.analysis_services_server.min_length
-      valid_name_unique = length(regexall(local.az.analysis_services_server.regex, local.az.analysis_services_server.name_unique)) > 0
+      valid_name_unique = local.az.analysis_services_server.name_unique != null ? length(regexall(local.az.analysis_services_server.regex, local.az.analysis_services_server.name_unique)) > 0 : null
     }
     api_management = {
       valid_name        = length(regexall(local.az.api_management.regex, local.az.api_management.name)) > 0 && length(local.az.api_management.name) > local.az.api_management.min_length
-      valid_name_unique = length(regexall(local.az.api_management.regex, local.az.api_management.name_unique)) > 0
+      valid_name_unique = local.az.api_management.name_unique != null ? length(regexall(local.az.api_management.regex, local.az.api_management.name_unique)) > 0 : null
     }
     app_configuration = {
       valid_name        = length(regexall(local.az.app_configuration.regex, local.az.app_configuration.name)) > 0 && length(local.az.app_configuration.name) > local.az.app_configuration.min_length
-      valid_name_unique = length(regexall(local.az.app_configuration.regex, local.az.app_configuration.name_unique)) > 0
+      valid_name_unique = local.az.app_configuration.name_unique != null ? length(regexall(local.az.app_configuration.regex, local.az.app_configuration.name_unique)) > 0 : null
     }
     app_service = {
       valid_name        = length(regexall(local.az.app_service.regex, local.az.app_service.name)) > 0 && length(local.az.app_service.name) > local.az.app_service.min_length
-      valid_name_unique = length(regexall(local.az.app_service.regex, local.az.app_service.name_unique)) > 0
+      valid_name_unique = local.az.app_service.name_unique != null ? length(regexall(local.az.app_service.regex, local.az.app_service.name_unique)) > 0 : null
     }
     app_service_environment = {
       valid_name        = length(regexall(local.az.app_service_environment.regex, local.az.app_service_environment.name)) > 0 && length(local.az.app_service_environment.name) > local.az.app_service_environment.min_length
-      valid_name_unique = length(regexall(local.az.app_service_environment.regex, local.az.app_service_environment.name_unique)) > 0
+      valid_name_unique = local.az.app_service_environment.name_unique != null ? length(regexall(local.az.app_service_environment.regex, local.az.app_service_environment.name_unique)) > 0 : null
     }
     app_service_plan = {
       valid_name        = length(regexall(local.az.app_service_plan.regex, local.az.app_service_plan.name)) > 0 && length(local.az.app_service_plan.name) > local.az.app_service_plan.min_length
-      valid_name_unique = length(regexall(local.az.app_service_plan.regex, local.az.app_service_plan.name_unique)) > 0
+      valid_name_unique = local.az.app_service_plan.name_unique != null ? length(regexall(local.az.app_service_plan.regex, local.az.app_service_plan.name_unique)) > 0 : null
     }
     application_gateway = {
       valid_name        = length(regexall(local.az.application_gateway.regex, local.az.application_gateway.name)) > 0 && length(local.az.application_gateway.name) > local.az.application_gateway.min_length
-      valid_name_unique = length(regexall(local.az.application_gateway.regex, local.az.application_gateway.name_unique)) > 0
+      valid_name_unique = local.az.application_gateway.name_unique != null ? length(regexall(local.az.application_gateway.regex, local.az.application_gateway.name_unique)) > 0 : null
     }
     application_insights = {
       valid_name        = length(regexall(local.az.application_insights.regex, local.az.application_insights.name)) > 0 && length(local.az.application_insights.name) > local.az.application_insights.min_length
-      valid_name_unique = length(regexall(local.az.application_insights.regex, local.az.application_insights.name_unique)) > 0
+      valid_name_unique = local.az.application_insights.name_unique != null ? length(regexall(local.az.application_insights.regex, local.az.application_insights.name_unique)) > 0 : null
     }
     application_security_group = {
       valid_name        = length(regexall(local.az.application_security_group.regex, local.az.application_security_group.name)) > 0 && length(local.az.application_security_group.name) > local.az.application_security_group.min_length
-      valid_name_unique = length(regexall(local.az.application_security_group.regex, local.az.application_security_group.name_unique)) > 0
+      valid_name_unique = local.az.application_security_group.name_unique != null ? length(regexall(local.az.application_security_group.regex, local.az.application_security_group.name_unique)) > 0 : null
     }
     automation_account = {
       valid_name        = length(regexall(local.az.automation_account.regex, local.az.automation_account.name)) > 0 && length(local.az.automation_account.name) > local.az.automation_account.min_length
-      valid_name_unique = length(regexall(local.az.automation_account.regex, local.az.automation_account.name_unique)) > 0
+      valid_name_unique = local.az.automation_account.name_unique != null ? length(regexall(local.az.automation_account.regex, local.az.automation_account.name_unique)) > 0 : null
     }
     automation_certificate = {
       valid_name        = length(regexall(local.az.automation_certificate.regex, local.az.automation_certificate.name)) > 0 && length(local.az.automation_certificate.name) > local.az.automation_certificate.min_length
-      valid_name_unique = length(regexall(local.az.automation_certificate.regex, local.az.automation_certificate.name_unique)) > 0
+      valid_name_unique = local.az.automation_certificate.name_unique != null ? length(regexall(local.az.automation_certificate.regex, local.az.automation_certificate.name_unique)) > 0 : null
     }
     automation_credential = {
       valid_name        = length(regexall(local.az.automation_credential.regex, local.az.automation_credential.name)) > 0 && length(local.az.automation_credential.name) > local.az.automation_credential.min_length
-      valid_name_unique = length(regexall(local.az.automation_credential.regex, local.az.automation_credential.name_unique)) > 0
+      valid_name_unique = local.az.automation_credential.name_unique != null ? length(regexall(local.az.automation_credential.regex, local.az.automation_credential.name_unique)) > 0 : null
     }
     automation_runbook = {
       valid_name        = length(regexall(local.az.automation_runbook.regex, local.az.automation_runbook.name)) > 0 && length(local.az.automation_runbook.name) > local.az.automation_runbook.min_length
-      valid_name_unique = length(regexall(local.az.automation_runbook.regex, local.az.automation_runbook.name_unique)) > 0
+      valid_name_unique = local.az.automation_runbook.name_unique != null ? length(regexall(local.az.automation_runbook.regex, local.az.automation_runbook.name_unique)) > 0 : null
     }
     automation_schedule = {
       valid_name        = length(regexall(local.az.automation_schedule.regex, local.az.automation_schedule.name)) > 0 && length(local.az.automation_schedule.name) > local.az.automation_schedule.min_length
-      valid_name_unique = length(regexall(local.az.automation_schedule.regex, local.az.automation_schedule.name_unique)) > 0
+      valid_name_unique = local.az.automation_schedule.name_unique != null ? length(regexall(local.az.automation_schedule.regex, local.az.automation_schedule.name_unique)) > 0 : null
     }
     automation_variable = {
       valid_name        = length(regexall(local.az.automation_variable.regex, local.az.automation_variable.name)) > 0 && length(local.az.automation_variable.name) > local.az.automation_variable.min_length
-      valid_name_unique = length(regexall(local.az.automation_variable.regex, local.az.automation_variable.name_unique)) > 0
+      valid_name_unique = local.az.automation_variable.name_unique != null ? length(regexall(local.az.automation_variable.regex, local.az.automation_variable.name_unique)) > 0 : null
     }
     availability_set = {
       valid_name        = length(regexall(local.az.availability_set.regex, local.az.availability_set.name)) > 0 && length(local.az.availability_set.name) > local.az.availability_set.min_length
-      valid_name_unique = length(regexall(local.az.availability_set.regex, local.az.availability_set.name_unique)) > 0
+      valid_name_unique = local.az.availability_set.name_unique != null ? length(regexall(local.az.availability_set.regex, local.az.availability_set.name_unique)) > 0 : null
     }
     backup_policy_vm = {
       valid_name        = length(regexall(local.az.backup_policy_vm.regex, local.az.backup_policy_vm.name)) > 0 && length(local.az.backup_policy_vm.name) > local.az.backup_policy_vm.min_length
-      valid_name_unique = length(regexall(local.az.backup_policy_vm.regex, local.az.backup_policy_vm.name_unique)) > 0
+      valid_name_unique = local.az.backup_policy_vm.name_unique != null ? length(regexall(local.az.backup_policy_vm.regex, local.az.backup_policy_vm.name_unique)) > 0 : null
     }
     bastion_host = {
       valid_name        = length(regexall(local.az.bastion_host.regex, local.az.bastion_host.name)) > 0 && length(local.az.bastion_host.name) > local.az.bastion_host.min_length
-      valid_name_unique = length(regexall(local.az.bastion_host.regex, local.az.bastion_host.name_unique)) > 0
+      valid_name_unique = local.az.bastion_host.name_unique != null ? length(regexall(local.az.bastion_host.regex, local.az.bastion_host.name_unique)) > 0 : null
     }
     batch_account = {
       valid_name        = length(regexall(local.az.batch_account.regex, local.az.batch_account.name)) > 0 && length(local.az.batch_account.name) > local.az.batch_account.min_length
-      valid_name_unique = length(regexall(local.az.batch_account.regex, local.az.batch_account.name_unique)) > 0
+      valid_name_unique = local.az.batch_account.name_unique != null ? length(regexall(local.az.batch_account.regex, local.az.batch_account.name_unique)) > 0 : null
     }
     batch_application = {
       valid_name        = length(regexall(local.az.batch_application.regex, local.az.batch_application.name)) > 0 && length(local.az.batch_application.name) > local.az.batch_application.min_length
-      valid_name_unique = length(regexall(local.az.batch_application.regex, local.az.batch_application.name_unique)) > 0
+      valid_name_unique = local.az.batch_application.name_unique != null ? length(regexall(local.az.batch_application.regex, local.az.batch_application.name_unique)) > 0 : null
     }
     batch_certificate = {
       valid_name        = length(regexall(local.az.batch_certificate.regex, local.az.batch_certificate.name)) > 0 && length(local.az.batch_certificate.name) > local.az.batch_certificate.min_length
-      valid_name_unique = length(regexall(local.az.batch_certificate.regex, local.az.batch_certificate.name_unique)) > 0
+      valid_name_unique = local.az.batch_certificate.name_unique != null ? length(regexall(local.az.batch_certificate.regex, local.az.batch_certificate.name_unique)) > 0 : null
     }
     batch_pool = {
       valid_name        = length(regexall(local.az.batch_pool.regex, local.az.batch_pool.name)) > 0 && length(local.az.batch_pool.name) > local.az.batch_pool.min_length
-      valid_name_unique = length(regexall(local.az.batch_pool.regex, local.az.batch_pool.name_unique)) > 0
+      valid_name_unique = local.az.batch_pool.name_unique != null ? length(regexall(local.az.batch_pool.regex, local.az.batch_pool.name_unique)) > 0 : null
     }
     bot_channel_directline = {
       valid_name        = length(regexall(local.az.bot_channel_directline.regex, local.az.bot_channel_directline.name)) > 0 && length(local.az.bot_channel_directline.name) > local.az.bot_channel_directline.min_length
-      valid_name_unique = length(regexall(local.az.bot_channel_directline.regex, local.az.bot_channel_directline.name_unique)) > 0
+      valid_name_unique = local.az.bot_channel_directline.name_unique != null ? length(regexall(local.az.bot_channel_directline.regex, local.az.bot_channel_directline.name_unique)) > 0 : null
     }
     bot_channel_email = {
       valid_name        = length(regexall(local.az.bot_channel_email.regex, local.az.bot_channel_email.name)) > 0 && length(local.az.bot_channel_email.name) > local.az.bot_channel_email.min_length
-      valid_name_unique = length(regexall(local.az.bot_channel_email.regex, local.az.bot_channel_email.name_unique)) > 0
+      valid_name_unique = local.az.bot_channel_email.name_unique != null ? length(regexall(local.az.bot_channel_email.regex, local.az.bot_channel_email.name_unique)) > 0 : null
     }
     bot_channel_ms_teams = {
       valid_name        = length(regexall(local.az.bot_channel_ms_teams.regex, local.az.bot_channel_ms_teams.name)) > 0 && length(local.az.bot_channel_ms_teams.name) > local.az.bot_channel_ms_teams.min_length
-      valid_name_unique = length(regexall(local.az.bot_channel_ms_teams.regex, local.az.bot_channel_ms_teams.name_unique)) > 0
+      valid_name_unique = local.az.bot_channel_ms_teams.name_unique != null ? length(regexall(local.az.bot_channel_ms_teams.regex, local.az.bot_channel_ms_teams.name_unique)) > 0 : null
     }
     bot_channel_slack = {
       valid_name        = length(regexall(local.az.bot_channel_slack.regex, local.az.bot_channel_slack.name)) > 0 && length(local.az.bot_channel_slack.name) > local.az.bot_channel_slack.min_length
-      valid_name_unique = length(regexall(local.az.bot_channel_slack.regex, local.az.bot_channel_slack.name_unique)) > 0
+      valid_name_unique = local.az.bot_channel_slack.name_unique != null ? length(regexall(local.az.bot_channel_slack.regex, local.az.bot_channel_slack.name_unique)) > 0 : null
     }
     bot_channels_registration = {
       valid_name        = length(regexall(local.az.bot_channels_registration.regex, local.az.bot_channels_registration.name)) > 0 && length(local.az.bot_channels_registration.name) > local.az.bot_channels_registration.min_length
-      valid_name_unique = length(regexall(local.az.bot_channels_registration.regex, local.az.bot_channels_registration.name_unique)) > 0
+      valid_name_unique = local.az.bot_channels_registration.name_unique != null ? length(regexall(local.az.bot_channels_registration.regex, local.az.bot_channels_registration.name_unique)) > 0 : null
     }
     bot_connection = {
       valid_name        = length(regexall(local.az.bot_connection.regex, local.az.bot_connection.name)) > 0 && length(local.az.bot_connection.name) > local.az.bot_connection.min_length
-      valid_name_unique = length(regexall(local.az.bot_connection.regex, local.az.bot_connection.name_unique)) > 0
+      valid_name_unique = local.az.bot_connection.name_unique != null ? length(regexall(local.az.bot_connection.regex, local.az.bot_connection.name_unique)) > 0 : null
     }
     bot_web_app = {
       valid_name        = length(regexall(local.az.bot_web_app.regex, local.az.bot_web_app.name)) > 0 && length(local.az.bot_web_app.name) > local.az.bot_web_app.min_length
-      valid_name_unique = length(regexall(local.az.bot_web_app.regex, local.az.bot_web_app.name_unique)) > 0
+      valid_name_unique = local.az.bot_web_app.name_unique != null ? length(regexall(local.az.bot_web_app.regex, local.az.bot_web_app.name_unique)) > 0 : null
     }
     cdn_endpoint = {
       valid_name        = length(regexall(local.az.cdn_endpoint.regex, local.az.cdn_endpoint.name)) > 0 && length(local.az.cdn_endpoint.name) > local.az.cdn_endpoint.min_length
-      valid_name_unique = length(regexall(local.az.cdn_endpoint.regex, local.az.cdn_endpoint.name_unique)) > 0
+      valid_name_unique = local.az.cdn_endpoint.name_unique != null ? length(regexall(local.az.cdn_endpoint.regex, local.az.cdn_endpoint.name_unique)) > 0 : null
     }
     cdn_frontdoor_endpoint = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_endpoint.regex, local.az.cdn_frontdoor_endpoint.name)) > 0 && length(local.az.cdn_frontdoor_endpoint.name) > local.az.cdn_frontdoor_endpoint.min_length
-      valid_name_unique = length(regexall(local.az.cdn_frontdoor_endpoint.regex, local.az.cdn_frontdoor_endpoint.name_unique)) > 0
+      valid_name_unique = local.az.cdn_frontdoor_endpoint.name_unique != null ? length(regexall(local.az.cdn_frontdoor_endpoint.regex, local.az.cdn_frontdoor_endpoint.name_unique)) > 0 : null
     }
     cdn_frontdoor_origin = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_origin.regex, local.az.cdn_frontdoor_origin.name)) > 0 && length(local.az.cdn_frontdoor_origin.name) > local.az.cdn_frontdoor_origin.min_length
-      valid_name_unique = length(regexall(local.az.cdn_frontdoor_origin.regex, local.az.cdn_frontdoor_origin.name_unique)) > 0
+      valid_name_unique = local.az.cdn_frontdoor_origin.name_unique != null ? length(regexall(local.az.cdn_frontdoor_origin.regex, local.az.cdn_frontdoor_origin.name_unique)) > 0 : null
     }
     cdn_frontdoor_origin_group = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_origin_group.regex, local.az.cdn_frontdoor_origin_group.name)) > 0 && length(local.az.cdn_frontdoor_origin_group.name) > local.az.cdn_frontdoor_origin_group.min_length
-      valid_name_unique = length(regexall(local.az.cdn_frontdoor_origin_group.regex, local.az.cdn_frontdoor_origin_group.name_unique)) > 0
+      valid_name_unique = local.az.cdn_frontdoor_origin_group.name_unique != null ? length(regexall(local.az.cdn_frontdoor_origin_group.regex, local.az.cdn_frontdoor_origin_group.name_unique)) > 0 : null
     }
     cdn_frontdoor_profile = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_profile.regex, local.az.cdn_frontdoor_profile.name)) > 0 && length(local.az.cdn_frontdoor_profile.name) > local.az.cdn_frontdoor_profile.min_length
-      valid_name_unique = length(regexall(local.az.cdn_frontdoor_profile.regex, local.az.cdn_frontdoor_profile.name_unique)) > 0
+      valid_name_unique = local.az.cdn_frontdoor_profile.name_unique != null ? length(regexall(local.az.cdn_frontdoor_profile.regex, local.az.cdn_frontdoor_profile.name_unique)) > 0 : null
     }
     cdn_frontdoor_route = {
       valid_name        = length(regexall(local.az.cdn_frontdoor_route.regex, local.az.cdn_frontdoor_route.name)) > 0 && length(local.az.cdn_frontdoor_route.name) > local.az.cdn_frontdoor_route.min_length
-      valid_name_unique = length(regexall(local.az.cdn_frontdoor_route.regex, local.az.cdn_frontdoor_route.name_unique)) > 0
+      valid_name_unique = local.az.cdn_frontdoor_route.name_unique != null ? length(regexall(local.az.cdn_frontdoor_route.regex, local.az.cdn_frontdoor_route.name_unique)) > 0 : null
     }
     cdn_profile = {
       valid_name        = length(regexall(local.az.cdn_profile.regex, local.az.cdn_profile.name)) > 0 && length(local.az.cdn_profile.name) > local.az.cdn_profile.min_length
-      valid_name_unique = length(regexall(local.az.cdn_profile.regex, local.az.cdn_profile.name_unique)) > 0
+      valid_name_unique = local.az.cdn_profile.name_unique != null ? length(regexall(local.az.cdn_profile.regex, local.az.cdn_profile.name_unique)) > 0 : null
     }
     cognitive_account = {
       valid_name        = length(regexall(local.az.cognitive_account.regex, local.az.cognitive_account.name)) > 0 && length(local.az.cognitive_account.name) > local.az.cognitive_account.min_length
-      valid_name_unique = length(regexall(local.az.cognitive_account.regex, local.az.cognitive_account.name_unique)) > 0
+      valid_name_unique = local.az.cognitive_account.name_unique != null ? length(regexall(local.az.cognitive_account.regex, local.az.cognitive_account.name_unique)) > 0 : null
     }
     communication_service = {
       valid_name        = length(regexall(local.az.communication_service.regex, local.az.communication_service.name)) > 0 && length(local.az.communication_service.name) > local.az.communication_service.min_length
-      valid_name_unique = length(regexall(local.az.communication_service.regex, local.az.communication_service.name_unique)) > 0
+      valid_name_unique = local.az.communication_service.name_unique != null ? length(regexall(local.az.communication_service.regex, local.az.communication_service.name_unique)) > 0 : null
     }
     container_app = {
       valid_name        = length(regexall(local.az.container_app.regex, local.az.container_app.name)) > 0 && length(local.az.container_app.name) > local.az.container_app.min_length
-      valid_name_unique = length(regexall(local.az.container_app.regex, local.az.container_app.name_unique)) > 0
+      valid_name_unique = local.az.container_app.name_unique != null ? length(regexall(local.az.container_app.regex, local.az.container_app.name_unique)) > 0 : null
     }
     container_app_environment = {
       valid_name        = length(regexall(local.az.container_app_environment.regex, local.az.container_app_environment.name)) > 0 && length(local.az.container_app_environment.name) > local.az.container_app_environment.min_length
-      valid_name_unique = length(regexall(local.az.container_app_environment.regex, local.az.container_app_environment.name_unique)) > 0
+      valid_name_unique = local.az.container_app_environment.name_unique != null ? length(regexall(local.az.container_app_environment.regex, local.az.container_app_environment.name_unique)) > 0 : null
     }
     container_app_job = {
       valid_name        = length(regexall(local.az.container_app_job.regex, local.az.container_app_job.name)) > 0 && length(local.az.container_app_job.name) > local.az.container_app_job.min_length
-      valid_name_unique = length(regexall(local.az.container_app_job.regex, local.az.container_app_job.name_unique)) > 0
+      valid_name_unique = local.az.container_app_job.name_unique != null ? length(regexall(local.az.container_app_job.regex, local.az.container_app_job.name_unique)) > 0 : null
     }
     container_group = {
       valid_name        = length(regexall(local.az.container_group.regex, local.az.container_group.name)) > 0 && length(local.az.container_group.name) > local.az.container_group.min_length
-      valid_name_unique = length(regexall(local.az.container_group.regex, local.az.container_group.name_unique)) > 0
+      valid_name_unique = local.az.container_group.name_unique != null ? length(regexall(local.az.container_group.regex, local.az.container_group.name_unique)) > 0 : null
     }
     container_registry = {
       valid_name        = length(regexall(local.az.container_registry.regex, local.az.container_registry.name)) > 0 && length(local.az.container_registry.name) > local.az.container_registry.min_length
-      valid_name_unique = length(regexall(local.az.container_registry.regex, local.az.container_registry.name_unique)) > 0
+      valid_name_unique = local.az.container_registry.name_unique != null ? length(regexall(local.az.container_registry.regex, local.az.container_registry.name_unique)) > 0 : null
     }
     container_registry_webhook = {
       valid_name        = length(regexall(local.az.container_registry_webhook.regex, local.az.container_registry_webhook.name)) > 0 && length(local.az.container_registry_webhook.name) > local.az.container_registry_webhook.min_length
-      valid_name_unique = length(regexall(local.az.container_registry_webhook.regex, local.az.container_registry_webhook.name_unique)) > 0
+      valid_name_unique = local.az.container_registry_webhook.name_unique != null ? length(regexall(local.az.container_registry_webhook.regex, local.az.container_registry_webhook.name_unique)) > 0 : null
     }
     cosmosdb_account = {
       valid_name        = length(regexall(local.az.cosmosdb_account.regex, local.az.cosmosdb_account.name)) > 0 && length(local.az.cosmosdb_account.name) > local.az.cosmosdb_account.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_account.regex, local.az.cosmosdb_account.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_account.name_unique != null ? length(regexall(local.az.cosmosdb_account.regex, local.az.cosmosdb_account.name_unique)) > 0 : null
     }
     cosmosdb_cassandra = {
       valid_name        = length(regexall(local.az.cosmosdb_cassandra.regex, local.az.cosmosdb_cassandra.name)) > 0 && length(local.az.cosmosdb_cassandra.name) > local.az.cosmosdb_cassandra.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_cassandra.regex, local.az.cosmosdb_cassandra.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_cassandra.name_unique != null ? length(regexall(local.az.cosmosdb_cassandra.regex, local.az.cosmosdb_cassandra.name_unique)) > 0 : null
     }
     cosmosdb_cassandra_cluster = {
       valid_name        = length(regexall(local.az.cosmosdb_cassandra_cluster.regex, local.az.cosmosdb_cassandra_cluster.name)) > 0 && length(local.az.cosmosdb_cassandra_cluster.name) > local.az.cosmosdb_cassandra_cluster.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_cassandra_cluster.regex, local.az.cosmosdb_cassandra_cluster.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_cassandra_cluster.name_unique != null ? length(regexall(local.az.cosmosdb_cassandra_cluster.regex, local.az.cosmosdb_cassandra_cluster.name_unique)) > 0 : null
     }
     cosmosdb_cassandra_datacenter = {
       valid_name        = length(regexall(local.az.cosmosdb_cassandra_datacenter.regex, local.az.cosmosdb_cassandra_datacenter.name)) > 0 && length(local.az.cosmosdb_cassandra_datacenter.name) > local.az.cosmosdb_cassandra_datacenter.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_cassandra_datacenter.regex, local.az.cosmosdb_cassandra_datacenter.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_cassandra_datacenter.name_unique != null ? length(regexall(local.az.cosmosdb_cassandra_datacenter.regex, local.az.cosmosdb_cassandra_datacenter.name_unique)) > 0 : null
     }
     cosmosdb_gremlin = {
       valid_name        = length(regexall(local.az.cosmosdb_gremlin.regex, local.az.cosmosdb_gremlin.name)) > 0 && length(local.az.cosmosdb_gremlin.name) > local.az.cosmosdb_gremlin.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_gremlin.regex, local.az.cosmosdb_gremlin.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_gremlin.name_unique != null ? length(regexall(local.az.cosmosdb_gremlin.regex, local.az.cosmosdb_gremlin.name_unique)) > 0 : null
     }
     cosmosdb_mongodb = {
       valid_name        = length(regexall(local.az.cosmosdb_mongodb.regex, local.az.cosmosdb_mongodb.name)) > 0 && length(local.az.cosmosdb_mongodb.name) > local.az.cosmosdb_mongodb.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_mongodb.regex, local.az.cosmosdb_mongodb.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_mongodb.name_unique != null ? length(regexall(local.az.cosmosdb_mongodb.regex, local.az.cosmosdb_mongodb.name_unique)) > 0 : null
     }
     cosmosdb_nosql = {
       valid_name        = length(regexall(local.az.cosmosdb_nosql.regex, local.az.cosmosdb_nosql.name)) > 0 && length(local.az.cosmosdb_nosql.name) > local.az.cosmosdb_nosql.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_nosql.regex, local.az.cosmosdb_nosql.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_nosql.name_unique != null ? length(regexall(local.az.cosmosdb_nosql.regex, local.az.cosmosdb_nosql.name_unique)) > 0 : null
     }
     cosmosdb_postgres = {
       valid_name        = length(regexall(local.az.cosmosdb_postgres.regex, local.az.cosmosdb_postgres.name)) > 0 && length(local.az.cosmosdb_postgres.name) > local.az.cosmosdb_postgres.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_postgres.regex, local.az.cosmosdb_postgres.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_postgres.name_unique != null ? length(regexall(local.az.cosmosdb_postgres.regex, local.az.cosmosdb_postgres.name_unique)) > 0 : null
     }
     cosmosdb_tables = {
       valid_name        = length(regexall(local.az.cosmosdb_tables.regex, local.az.cosmosdb_tables.name)) > 0 && length(local.az.cosmosdb_tables.name) > local.az.cosmosdb_tables.min_length
-      valid_name_unique = length(regexall(local.az.cosmosdb_tables.regex, local.az.cosmosdb_tables.name_unique)) > 0
+      valid_name_unique = local.az.cosmosdb_tables.name_unique != null ? length(regexall(local.az.cosmosdb_tables.regex, local.az.cosmosdb_tables.name_unique)) > 0 : null
     }
     custom_provider = {
       valid_name        = length(regexall(local.az.custom_provider.regex, local.az.custom_provider.name)) > 0 && length(local.az.custom_provider.name) > local.az.custom_provider.min_length
-      valid_name_unique = length(regexall(local.az.custom_provider.regex, local.az.custom_provider.name_unique)) > 0
+      valid_name_unique = local.az.custom_provider.name_unique != null ? length(regexall(local.az.custom_provider.regex, local.az.custom_provider.name_unique)) > 0 : null
     }
     dashboard = {
       valid_name        = length(regexall(local.az.dashboard.regex, local.az.dashboard.name)) > 0 && length(local.az.dashboard.name) > local.az.dashboard.min_length
-      valid_name_unique = length(regexall(local.az.dashboard.regex, local.az.dashboard.name_unique)) > 0
+      valid_name_unique = local.az.dashboard.name_unique != null ? length(regexall(local.az.dashboard.regex, local.az.dashboard.name_unique)) > 0 : null
     }
     dashboard_grafana = {
       valid_name        = length(regexall(local.az.dashboard_grafana.regex, local.az.dashboard_grafana.name)) > 0 && length(local.az.dashboard_grafana.name) > local.az.dashboard_grafana.min_length
-      valid_name_unique = length(regexall(local.az.dashboard_grafana.regex, local.az.dashboard_grafana.name_unique)) > 0
+      valid_name_unique = local.az.dashboard_grafana.name_unique != null ? length(regexall(local.az.dashboard_grafana.regex, local.az.dashboard_grafana.name_unique)) > 0 : null
     }
     data_factory = {
       valid_name        = length(regexall(local.az.data_factory.regex, local.az.data_factory.name)) > 0 && length(local.az.data_factory.name) > local.az.data_factory.min_length
-      valid_name_unique = length(regexall(local.az.data_factory.regex, local.az.data_factory.name_unique)) > 0
+      valid_name_unique = local.az.data_factory.name_unique != null ? length(regexall(local.az.data_factory.regex, local.az.data_factory.name_unique)) > 0 : null
     }
     data_factory_dataset_mysql = {
       valid_name        = length(regexall(local.az.data_factory_dataset_mysql.regex, local.az.data_factory_dataset_mysql.name)) > 0 && length(local.az.data_factory_dataset_mysql.name) > local.az.data_factory_dataset_mysql.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_dataset_mysql.regex, local.az.data_factory_dataset_mysql.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_dataset_mysql.name_unique != null ? length(regexall(local.az.data_factory_dataset_mysql.regex, local.az.data_factory_dataset_mysql.name_unique)) > 0 : null
     }
     data_factory_dataset_postgresql = {
       valid_name        = length(regexall(local.az.data_factory_dataset_postgresql.regex, local.az.data_factory_dataset_postgresql.name)) > 0 && length(local.az.data_factory_dataset_postgresql.name) > local.az.data_factory_dataset_postgresql.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_dataset_postgresql.regex, local.az.data_factory_dataset_postgresql.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_dataset_postgresql.name_unique != null ? length(regexall(local.az.data_factory_dataset_postgresql.regex, local.az.data_factory_dataset_postgresql.name_unique)) > 0 : null
     }
     data_factory_dataset_sql_server_table = {
       valid_name        = length(regexall(local.az.data_factory_dataset_sql_server_table.regex, local.az.data_factory_dataset_sql_server_table.name)) > 0 && length(local.az.data_factory_dataset_sql_server_table.name) > local.az.data_factory_dataset_sql_server_table.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_dataset_sql_server_table.regex, local.az.data_factory_dataset_sql_server_table.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_dataset_sql_server_table.name_unique != null ? length(regexall(local.az.data_factory_dataset_sql_server_table.regex, local.az.data_factory_dataset_sql_server_table.name_unique)) > 0 : null
     }
     data_factory_integration_runtime_managed = {
       valid_name        = length(regexall(local.az.data_factory_integration_runtime_managed.regex, local.az.data_factory_integration_runtime_managed.name)) > 0 && length(local.az.data_factory_integration_runtime_managed.name) > local.az.data_factory_integration_runtime_managed.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_integration_runtime_managed.regex, local.az.data_factory_integration_runtime_managed.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_integration_runtime_managed.name_unique != null ? length(regexall(local.az.data_factory_integration_runtime_managed.regex, local.az.data_factory_integration_runtime_managed.name_unique)) > 0 : null
     }
     data_factory_linked_service_data_lake_storage_gen2 = {
       valid_name        = length(regexall(local.az.data_factory_linked_service_data_lake_storage_gen2.regex, local.az.data_factory_linked_service_data_lake_storage_gen2.name)) > 0 && length(local.az.data_factory_linked_service_data_lake_storage_gen2.name) > local.az.data_factory_linked_service_data_lake_storage_gen2.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_linked_service_data_lake_storage_gen2.regex, local.az.data_factory_linked_service_data_lake_storage_gen2.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_linked_service_data_lake_storage_gen2.name_unique != null ? length(regexall(local.az.data_factory_linked_service_data_lake_storage_gen2.regex, local.az.data_factory_linked_service_data_lake_storage_gen2.name_unique)) > 0 : null
     }
     data_factory_linked_service_key_vault = {
       valid_name        = length(regexall(local.az.data_factory_linked_service_key_vault.regex, local.az.data_factory_linked_service_key_vault.name)) > 0 && length(local.az.data_factory_linked_service_key_vault.name) > local.az.data_factory_linked_service_key_vault.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_linked_service_key_vault.regex, local.az.data_factory_linked_service_key_vault.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_linked_service_key_vault.name_unique != null ? length(regexall(local.az.data_factory_linked_service_key_vault.regex, local.az.data_factory_linked_service_key_vault.name_unique)) > 0 : null
     }
     data_factory_linked_service_mysql = {
       valid_name        = length(regexall(local.az.data_factory_linked_service_mysql.regex, local.az.data_factory_linked_service_mysql.name)) > 0 && length(local.az.data_factory_linked_service_mysql.name) > local.az.data_factory_linked_service_mysql.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_linked_service_mysql.regex, local.az.data_factory_linked_service_mysql.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_linked_service_mysql.name_unique != null ? length(regexall(local.az.data_factory_linked_service_mysql.regex, local.az.data_factory_linked_service_mysql.name_unique)) > 0 : null
     }
     data_factory_linked_service_postgresql = {
       valid_name        = length(regexall(local.az.data_factory_linked_service_postgresql.regex, local.az.data_factory_linked_service_postgresql.name)) > 0 && length(local.az.data_factory_linked_service_postgresql.name) > local.az.data_factory_linked_service_postgresql.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_linked_service_postgresql.regex, local.az.data_factory_linked_service_postgresql.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_linked_service_postgresql.name_unique != null ? length(regexall(local.az.data_factory_linked_service_postgresql.regex, local.az.data_factory_linked_service_postgresql.name_unique)) > 0 : null
     }
     data_factory_linked_service_sql_server = {
       valid_name        = length(regexall(local.az.data_factory_linked_service_sql_server.regex, local.az.data_factory_linked_service_sql_server.name)) > 0 && length(local.az.data_factory_linked_service_sql_server.name) > local.az.data_factory_linked_service_sql_server.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_linked_service_sql_server.regex, local.az.data_factory_linked_service_sql_server.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_linked_service_sql_server.name_unique != null ? length(regexall(local.az.data_factory_linked_service_sql_server.regex, local.az.data_factory_linked_service_sql_server.name_unique)) > 0 : null
     }
     data_factory_pipeline = {
       valid_name        = length(regexall(local.az.data_factory_pipeline.regex, local.az.data_factory_pipeline.name)) > 0 && length(local.az.data_factory_pipeline.name) > local.az.data_factory_pipeline.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_pipeline.regex, local.az.data_factory_pipeline.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_pipeline.name_unique != null ? length(regexall(local.az.data_factory_pipeline.regex, local.az.data_factory_pipeline.name_unique)) > 0 : null
     }
     data_factory_trigger_schedule = {
       valid_name        = length(regexall(local.az.data_factory_trigger_schedule.regex, local.az.data_factory_trigger_schedule.name)) > 0 && length(local.az.data_factory_trigger_schedule.name) > local.az.data_factory_trigger_schedule.min_length
-      valid_name_unique = length(regexall(local.az.data_factory_trigger_schedule.regex, local.az.data_factory_trigger_schedule.name_unique)) > 0
+      valid_name_unique = local.az.data_factory_trigger_schedule.name_unique != null ? length(regexall(local.az.data_factory_trigger_schedule.regex, local.az.data_factory_trigger_schedule.name_unique)) > 0 : null
     }
     data_lake_analytics_account = {
       valid_name        = length(regexall(local.az.data_lake_analytics_account.regex, local.az.data_lake_analytics_account.name)) > 0 && length(local.az.data_lake_analytics_account.name) > local.az.data_lake_analytics_account.min_length
-      valid_name_unique = length(regexall(local.az.data_lake_analytics_account.regex, local.az.data_lake_analytics_account.name_unique)) > 0
+      valid_name_unique = local.az.data_lake_analytics_account.name_unique != null ? length(regexall(local.az.data_lake_analytics_account.regex, local.az.data_lake_analytics_account.name_unique)) > 0 : null
     }
     data_lake_analytics_firewall_rule = {
       valid_name        = length(regexall(local.az.data_lake_analytics_firewall_rule.regex, local.az.data_lake_analytics_firewall_rule.name)) > 0 && length(local.az.data_lake_analytics_firewall_rule.name) > local.az.data_lake_analytics_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.data_lake_analytics_firewall_rule.regex, local.az.data_lake_analytics_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.data_lake_analytics_firewall_rule.name_unique != null ? length(regexall(local.az.data_lake_analytics_firewall_rule.regex, local.az.data_lake_analytics_firewall_rule.name_unique)) > 0 : null
     }
     data_lake_store = {
       valid_name        = length(regexall(local.az.data_lake_store.regex, local.az.data_lake_store.name)) > 0 && length(local.az.data_lake_store.name) > local.az.data_lake_store.min_length
-      valid_name_unique = length(regexall(local.az.data_lake_store.regex, local.az.data_lake_store.name_unique)) > 0
+      valid_name_unique = local.az.data_lake_store.name_unique != null ? length(regexall(local.az.data_lake_store.regex, local.az.data_lake_store.name_unique)) > 0 : null
     }
     data_lake_store_firewall_rule = {
       valid_name        = length(regexall(local.az.data_lake_store_firewall_rule.regex, local.az.data_lake_store_firewall_rule.name)) > 0 && length(local.az.data_lake_store_firewall_rule.name) > local.az.data_lake_store_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.data_lake_store_firewall_rule.regex, local.az.data_lake_store_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.data_lake_store_firewall_rule.name_unique != null ? length(regexall(local.az.data_lake_store_firewall_rule.regex, local.az.data_lake_store_firewall_rule.name_unique)) > 0 : null
     }
     data_protection_backup_vault = {
       valid_name        = length(regexall(local.az.data_protection_backup_vault.regex, local.az.data_protection_backup_vault.name)) > 0 && length(local.az.data_protection_backup_vault.name) > local.az.data_protection_backup_vault.min_length
-      valid_name_unique = length(regexall(local.az.data_protection_backup_vault.regex, local.az.data_protection_backup_vault.name_unique)) > 0
+      valid_name_unique = local.az.data_protection_backup_vault.name_unique != null ? length(regexall(local.az.data_protection_backup_vault.regex, local.az.data_protection_backup_vault.name_unique)) > 0 : null
     }
     database_migration_project = {
       valid_name        = length(regexall(local.az.database_migration_project.regex, local.az.database_migration_project.name)) > 0 && length(local.az.database_migration_project.name) > local.az.database_migration_project.min_length
-      valid_name_unique = length(regexall(local.az.database_migration_project.regex, local.az.database_migration_project.name_unique)) > 0
+      valid_name_unique = local.az.database_migration_project.name_unique != null ? length(regexall(local.az.database_migration_project.regex, local.az.database_migration_project.name_unique)) > 0 : null
     }
     database_migration_service = {
       valid_name        = length(regexall(local.az.database_migration_service.regex, local.az.database_migration_service.name)) > 0 && length(local.az.database_migration_service.name) > local.az.database_migration_service.min_length
-      valid_name_unique = length(regexall(local.az.database_migration_service.regex, local.az.database_migration_service.name_unique)) > 0
+      valid_name_unique = local.az.database_migration_service.name_unique != null ? length(regexall(local.az.database_migration_service.regex, local.az.database_migration_service.name_unique)) > 0 : null
     }
     databricks_access_connector = {
       valid_name        = length(regexall(local.az.databricks_access_connector.regex, local.az.databricks_access_connector.name)) > 0 && length(local.az.databricks_access_connector.name) > local.az.databricks_access_connector.min_length
-      valid_name_unique = length(regexall(local.az.databricks_access_connector.regex, local.az.databricks_access_connector.name_unique)) > 0
+      valid_name_unique = local.az.databricks_access_connector.name_unique != null ? length(regexall(local.az.databricks_access_connector.regex, local.az.databricks_access_connector.name_unique)) > 0 : null
     }
     databricks_cluster = {
       valid_name        = length(regexall(local.az.databricks_cluster.regex, local.az.databricks_cluster.name)) > 0 && length(local.az.databricks_cluster.name) > local.az.databricks_cluster.min_length
-      valid_name_unique = length(regexall(local.az.databricks_cluster.regex, local.az.databricks_cluster.name_unique)) > 0
+      valid_name_unique = local.az.databricks_cluster.name_unique != null ? length(regexall(local.az.databricks_cluster.regex, local.az.databricks_cluster.name_unique)) > 0 : null
     }
     databricks_high_concurrency_cluster = {
       valid_name        = length(regexall(local.az.databricks_high_concurrency_cluster.regex, local.az.databricks_high_concurrency_cluster.name)) > 0 && length(local.az.databricks_high_concurrency_cluster.name) > local.az.databricks_high_concurrency_cluster.min_length
-      valid_name_unique = length(regexall(local.az.databricks_high_concurrency_cluster.regex, local.az.databricks_high_concurrency_cluster.name_unique)) > 0
+      valid_name_unique = local.az.databricks_high_concurrency_cluster.name_unique != null ? length(regexall(local.az.databricks_high_concurrency_cluster.regex, local.az.databricks_high_concurrency_cluster.name_unique)) > 0 : null
     }
     databricks_standard_cluster = {
       valid_name        = length(regexall(local.az.databricks_standard_cluster.regex, local.az.databricks_standard_cluster.name)) > 0 && length(local.az.databricks_standard_cluster.name) > local.az.databricks_standard_cluster.min_length
-      valid_name_unique = length(regexall(local.az.databricks_standard_cluster.regex, local.az.databricks_standard_cluster.name_unique)) > 0
+      valid_name_unique = local.az.databricks_standard_cluster.name_unique != null ? length(regexall(local.az.databricks_standard_cluster.regex, local.az.databricks_standard_cluster.name_unique)) > 0 : null
     }
     databricks_workspace = {
       valid_name        = length(regexall(local.az.databricks_workspace.regex, local.az.databricks_workspace.name)) > 0 && length(local.az.databricks_workspace.name) > local.az.databricks_workspace.min_length
-      valid_name_unique = length(regexall(local.az.databricks_workspace.regex, local.az.databricks_workspace.name_unique)) > 0
+      valid_name_unique = local.az.databricks_workspace.name_unique != null ? length(regexall(local.az.databricks_workspace.regex, local.az.databricks_workspace.name_unique)) > 0 : null
     }
     dev_test_lab = {
       valid_name        = length(regexall(local.az.dev_test_lab.regex, local.az.dev_test_lab.name)) > 0 && length(local.az.dev_test_lab.name) > local.az.dev_test_lab.min_length
-      valid_name_unique = length(regexall(local.az.dev_test_lab.regex, local.az.dev_test_lab.name_unique)) > 0
+      valid_name_unique = local.az.dev_test_lab.name_unique != null ? length(regexall(local.az.dev_test_lab.regex, local.az.dev_test_lab.name_unique)) > 0 : null
     }
     dev_test_linux_virtual_machine = {
       valid_name        = length(regexall(local.az.dev_test_linux_virtual_machine.regex, local.az.dev_test_linux_virtual_machine.name)) > 0 && length(local.az.dev_test_linux_virtual_machine.name) > local.az.dev_test_linux_virtual_machine.min_length
-      valid_name_unique = length(regexall(local.az.dev_test_linux_virtual_machine.regex, local.az.dev_test_linux_virtual_machine.name_unique)) > 0
+      valid_name_unique = local.az.dev_test_linux_virtual_machine.name_unique != null ? length(regexall(local.az.dev_test_linux_virtual_machine.regex, local.az.dev_test_linux_virtual_machine.name_unique)) > 0 : null
     }
     dev_test_windows_virtual_machine = {
       valid_name        = length(regexall(local.az.dev_test_windows_virtual_machine.regex, local.az.dev_test_windows_virtual_machine.name)) > 0 && length(local.az.dev_test_windows_virtual_machine.name) > local.az.dev_test_windows_virtual_machine.min_length
-      valid_name_unique = length(regexall(local.az.dev_test_windows_virtual_machine.regex, local.az.dev_test_windows_virtual_machine.name_unique)) > 0
+      valid_name_unique = local.az.dev_test_windows_virtual_machine.name_unique != null ? length(regexall(local.az.dev_test_windows_virtual_machine.regex, local.az.dev_test_windows_virtual_machine.name_unique)) > 0 : null
     }
     disk_encryption_set = {
       valid_name        = length(regexall(local.az.disk_encryption_set.regex, local.az.disk_encryption_set.name)) > 0 && length(local.az.disk_encryption_set.name) > local.az.disk_encryption_set.min_length
-      valid_name_unique = length(regexall(local.az.disk_encryption_set.regex, local.az.disk_encryption_set.name_unique)) > 0
+      valid_name_unique = local.az.disk_encryption_set.name_unique != null ? length(regexall(local.az.disk_encryption_set.regex, local.az.disk_encryption_set.name_unique)) > 0 : null
     }
     dns_a_record = {
       valid_name        = length(regexall(local.az.dns_a_record.regex, local.az.dns_a_record.name)) > 0 && length(local.az.dns_a_record.name) > local.az.dns_a_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_a_record.regex, local.az.dns_a_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_a_record.name_unique != null ? length(regexall(local.az.dns_a_record.regex, local.az.dns_a_record.name_unique)) > 0 : null
     }
     dns_aaaa_record = {
       valid_name        = length(regexall(local.az.dns_aaaa_record.regex, local.az.dns_aaaa_record.name)) > 0 && length(local.az.dns_aaaa_record.name) > local.az.dns_aaaa_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_aaaa_record.regex, local.az.dns_aaaa_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_aaaa_record.name_unique != null ? length(regexall(local.az.dns_aaaa_record.regex, local.az.dns_aaaa_record.name_unique)) > 0 : null
     }
     dns_caa_record = {
       valid_name        = length(regexall(local.az.dns_caa_record.regex, local.az.dns_caa_record.name)) > 0 && length(local.az.dns_caa_record.name) > local.az.dns_caa_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_caa_record.regex, local.az.dns_caa_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_caa_record.name_unique != null ? length(regexall(local.az.dns_caa_record.regex, local.az.dns_caa_record.name_unique)) > 0 : null
     }
     dns_cname_record = {
       valid_name        = length(regexall(local.az.dns_cname_record.regex, local.az.dns_cname_record.name)) > 0 && length(local.az.dns_cname_record.name) > local.az.dns_cname_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_cname_record.regex, local.az.dns_cname_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_cname_record.name_unique != null ? length(regexall(local.az.dns_cname_record.regex, local.az.dns_cname_record.name_unique)) > 0 : null
     }
     dns_mx_record = {
       valid_name        = length(regexall(local.az.dns_mx_record.regex, local.az.dns_mx_record.name)) > 0 && length(local.az.dns_mx_record.name) > local.az.dns_mx_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_mx_record.regex, local.az.dns_mx_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_mx_record.name_unique != null ? length(regexall(local.az.dns_mx_record.regex, local.az.dns_mx_record.name_unique)) > 0 : null
     }
     dns_ns_record = {
       valid_name        = length(regexall(local.az.dns_ns_record.regex, local.az.dns_ns_record.name)) > 0 && length(local.az.dns_ns_record.name) > local.az.dns_ns_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_ns_record.regex, local.az.dns_ns_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_ns_record.name_unique != null ? length(regexall(local.az.dns_ns_record.regex, local.az.dns_ns_record.name_unique)) > 0 : null
     }
     dns_private_resolver = {
       valid_name        = length(regexall(local.az.dns_private_resolver.regex, local.az.dns_private_resolver.name)) > 0 && length(local.az.dns_private_resolver.name) > local.az.dns_private_resolver.min_length
-      valid_name_unique = length(regexall(local.az.dns_private_resolver.regex, local.az.dns_private_resolver.name_unique)) > 0
+      valid_name_unique = local.az.dns_private_resolver.name_unique != null ? length(regexall(local.az.dns_private_resolver.regex, local.az.dns_private_resolver.name_unique)) > 0 : null
     }
     dns_ptr_record = {
       valid_name        = length(regexall(local.az.dns_ptr_record.regex, local.az.dns_ptr_record.name)) > 0 && length(local.az.dns_ptr_record.name) > local.az.dns_ptr_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_ptr_record.regex, local.az.dns_ptr_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_ptr_record.name_unique != null ? length(regexall(local.az.dns_ptr_record.regex, local.az.dns_ptr_record.name_unique)) > 0 : null
     }
     dns_txt_record = {
       valid_name        = length(regexall(local.az.dns_txt_record.regex, local.az.dns_txt_record.name)) > 0 && length(local.az.dns_txt_record.name) > local.az.dns_txt_record.min_length
-      valid_name_unique = length(regexall(local.az.dns_txt_record.regex, local.az.dns_txt_record.name_unique)) > 0
+      valid_name_unique = local.az.dns_txt_record.name_unique != null ? length(regexall(local.az.dns_txt_record.regex, local.az.dns_txt_record.name_unique)) > 0 : null
     }
     dns_zone = {
       valid_name        = length(regexall(local.az.dns_zone.regex, local.az.dns_zone.name)) > 0 && length(local.az.dns_zone.name) > local.az.dns_zone.min_length
-      valid_name_unique = length(regexall(local.az.dns_zone.regex, local.az.dns_zone.name_unique)) > 0
+      valid_name_unique = local.az.dns_zone.name_unique != null ? length(regexall(local.az.dns_zone.regex, local.az.dns_zone.name_unique)) > 0 : null
     }
     eventgrid_domain = {
       valid_name        = length(regexall(local.az.eventgrid_domain.regex, local.az.eventgrid_domain.name)) > 0 && length(local.az.eventgrid_domain.name) > local.az.eventgrid_domain.min_length
-      valid_name_unique = length(regexall(local.az.eventgrid_domain.regex, local.az.eventgrid_domain.name_unique)) > 0
+      valid_name_unique = local.az.eventgrid_domain.name_unique != null ? length(regexall(local.az.eventgrid_domain.regex, local.az.eventgrid_domain.name_unique)) > 0 : null
     }
     eventgrid_domain_topic = {
       valid_name        = length(regexall(local.az.eventgrid_domain_topic.regex, local.az.eventgrid_domain_topic.name)) > 0 && length(local.az.eventgrid_domain_topic.name) > local.az.eventgrid_domain_topic.min_length
-      valid_name_unique = length(regexall(local.az.eventgrid_domain_topic.regex, local.az.eventgrid_domain_topic.name_unique)) > 0
+      valid_name_unique = local.az.eventgrid_domain_topic.name_unique != null ? length(regexall(local.az.eventgrid_domain_topic.regex, local.az.eventgrid_domain_topic.name_unique)) > 0 : null
     }
     eventgrid_event_subscription = {
       valid_name        = length(regexall(local.az.eventgrid_event_subscription.regex, local.az.eventgrid_event_subscription.name)) > 0 && length(local.az.eventgrid_event_subscription.name) > local.az.eventgrid_event_subscription.min_length
-      valid_name_unique = length(regexall(local.az.eventgrid_event_subscription.regex, local.az.eventgrid_event_subscription.name_unique)) > 0
+      valid_name_unique = local.az.eventgrid_event_subscription.name_unique != null ? length(regexall(local.az.eventgrid_event_subscription.regex, local.az.eventgrid_event_subscription.name_unique)) > 0 : null
     }
     eventgrid_namespace = {
       valid_name        = length(regexall(local.az.eventgrid_namespace.regex, local.az.eventgrid_namespace.name)) > 0 && length(local.az.eventgrid_namespace.name) > local.az.eventgrid_namespace.min_length
-      valid_name_unique = length(regexall(local.az.eventgrid_namespace.regex, local.az.eventgrid_namespace.name_unique)) > 0
+      valid_name_unique = local.az.eventgrid_namespace.name_unique != null ? length(regexall(local.az.eventgrid_namespace.regex, local.az.eventgrid_namespace.name_unique)) > 0 : null
     }
     eventgrid_system_topic = {
       valid_name        = length(regexall(local.az.eventgrid_system_topic.regex, local.az.eventgrid_system_topic.name)) > 0 && length(local.az.eventgrid_system_topic.name) > local.az.eventgrid_system_topic.min_length
-      valid_name_unique = length(regexall(local.az.eventgrid_system_topic.regex, local.az.eventgrid_system_topic.name_unique)) > 0
+      valid_name_unique = local.az.eventgrid_system_topic.name_unique != null ? length(regexall(local.az.eventgrid_system_topic.regex, local.az.eventgrid_system_topic.name_unique)) > 0 : null
     }
     eventgrid_topic = {
       valid_name        = length(regexall(local.az.eventgrid_topic.regex, local.az.eventgrid_topic.name)) > 0 && length(local.az.eventgrid_topic.name) > local.az.eventgrid_topic.min_length
-      valid_name_unique = length(regexall(local.az.eventgrid_topic.regex, local.az.eventgrid_topic.name_unique)) > 0
+      valid_name_unique = local.az.eventgrid_topic.name_unique != null ? length(regexall(local.az.eventgrid_topic.regex, local.az.eventgrid_topic.name_unique)) > 0 : null
     }
     eventhub = {
       valid_name        = length(regexall(local.az.eventhub.regex, local.az.eventhub.name)) > 0 && length(local.az.eventhub.name) > local.az.eventhub.min_length
-      valid_name_unique = length(regexall(local.az.eventhub.regex, local.az.eventhub.name_unique)) > 0
+      valid_name_unique = local.az.eventhub.name_unique != null ? length(regexall(local.az.eventhub.regex, local.az.eventhub.name_unique)) > 0 : null
     }
     eventhub_authorization_rule = {
       valid_name        = length(regexall(local.az.eventhub_authorization_rule.regex, local.az.eventhub_authorization_rule.name)) > 0 && length(local.az.eventhub_authorization_rule.name) > local.az.eventhub_authorization_rule.min_length
-      valid_name_unique = length(regexall(local.az.eventhub_authorization_rule.regex, local.az.eventhub_authorization_rule.name_unique)) > 0
+      valid_name_unique = local.az.eventhub_authorization_rule.name_unique != null ? length(regexall(local.az.eventhub_authorization_rule.regex, local.az.eventhub_authorization_rule.name_unique)) > 0 : null
     }
     eventhub_cluster = {
       valid_name        = length(regexall(local.az.eventhub_cluster.regex, local.az.eventhub_cluster.name)) > 0 && length(local.az.eventhub_cluster.name) > local.az.eventhub_cluster.min_length
-      valid_name_unique = length(regexall(local.az.eventhub_cluster.regex, local.az.eventhub_cluster.name_unique)) > 0
+      valid_name_unique = local.az.eventhub_cluster.name_unique != null ? length(regexall(local.az.eventhub_cluster.regex, local.az.eventhub_cluster.name_unique)) > 0 : null
     }
     eventhub_consumer_group = {
       valid_name        = length(regexall(local.az.eventhub_consumer_group.regex, local.az.eventhub_consumer_group.name)) > 0 && length(local.az.eventhub_consumer_group.name) > local.az.eventhub_consumer_group.min_length
-      valid_name_unique = length(regexall(local.az.eventhub_consumer_group.regex, local.az.eventhub_consumer_group.name_unique)) > 0
+      valid_name_unique = local.az.eventhub_consumer_group.name_unique != null ? length(regexall(local.az.eventhub_consumer_group.regex, local.az.eventhub_consumer_group.name_unique)) > 0 : null
     }
     eventhub_namespace = {
       valid_name        = length(regexall(local.az.eventhub_namespace.regex, local.az.eventhub_namespace.name)) > 0 && length(local.az.eventhub_namespace.name) > local.az.eventhub_namespace.min_length
-      valid_name_unique = length(regexall(local.az.eventhub_namespace.regex, local.az.eventhub_namespace.name_unique)) > 0
+      valid_name_unique = local.az.eventhub_namespace.name_unique != null ? length(regexall(local.az.eventhub_namespace.regex, local.az.eventhub_namespace.name_unique)) > 0 : null
     }
     eventhub_namespace_authorization_rule = {
       valid_name        = length(regexall(local.az.eventhub_namespace_authorization_rule.regex, local.az.eventhub_namespace_authorization_rule.name)) > 0 && length(local.az.eventhub_namespace_authorization_rule.name) > local.az.eventhub_namespace_authorization_rule.min_length
-      valid_name_unique = length(regexall(local.az.eventhub_namespace_authorization_rule.regex, local.az.eventhub_namespace_authorization_rule.name_unique)) > 0
+      valid_name_unique = local.az.eventhub_namespace_authorization_rule.name_unique != null ? length(regexall(local.az.eventhub_namespace_authorization_rule.regex, local.az.eventhub_namespace_authorization_rule.name_unique)) > 0 : null
     }
     eventhub_namespace_disaster_recovery_config = {
       valid_name        = length(regexall(local.az.eventhub_namespace_disaster_recovery_config.regex, local.az.eventhub_namespace_disaster_recovery_config.name)) > 0 && length(local.az.eventhub_namespace_disaster_recovery_config.name) > local.az.eventhub_namespace_disaster_recovery_config.min_length
-      valid_name_unique = length(regexall(local.az.eventhub_namespace_disaster_recovery_config.regex, local.az.eventhub_namespace_disaster_recovery_config.name_unique)) > 0
+      valid_name_unique = local.az.eventhub_namespace_disaster_recovery_config.name_unique != null ? length(regexall(local.az.eventhub_namespace_disaster_recovery_config.regex, local.az.eventhub_namespace_disaster_recovery_config.name_unique)) > 0 : null
     }
     express_route_circuit = {
       valid_name        = length(regexall(local.az.express_route_circuit.regex, local.az.express_route_circuit.name)) > 0 && length(local.az.express_route_circuit.name) > local.az.express_route_circuit.min_length
-      valid_name_unique = length(regexall(local.az.express_route_circuit.regex, local.az.express_route_circuit.name_unique)) > 0
+      valid_name_unique = local.az.express_route_circuit.name_unique != null ? length(regexall(local.az.express_route_circuit.regex, local.az.express_route_circuit.name_unique)) > 0 : null
     }
     express_route_gateway = {
       valid_name        = length(regexall(local.az.express_route_gateway.regex, local.az.express_route_gateway.name)) > 0 && length(local.az.express_route_gateway.name) > local.az.express_route_gateway.min_length
-      valid_name_unique = length(regexall(local.az.express_route_gateway.regex, local.az.express_route_gateway.name_unique)) > 0
+      valid_name_unique = local.az.express_route_gateway.name_unique != null ? length(regexall(local.az.express_route_gateway.regex, local.az.express_route_gateway.name_unique)) > 0 : null
     }
     fabric_capacity = {
       valid_name        = length(regexall(local.az.fabric_capacity.regex, local.az.fabric_capacity.name)) > 0 && length(local.az.fabric_capacity.name) > local.az.fabric_capacity.min_length
-      valid_name_unique = length(regexall(local.az.fabric_capacity.regex, local.az.fabric_capacity.name_unique)) > 0
+      valid_name_unique = local.az.fabric_capacity.name_unique != null ? length(regexall(local.az.fabric_capacity.regex, local.az.fabric_capacity.name_unique)) > 0 : null
     }
     firewall = {
       valid_name        = length(regexall(local.az.firewall.regex, local.az.firewall.name)) > 0 && length(local.az.firewall.name) > local.az.firewall.min_length
-      valid_name_unique = length(regexall(local.az.firewall.regex, local.az.firewall.name_unique)) > 0
+      valid_name_unique = local.az.firewall.name_unique != null ? length(regexall(local.az.firewall.regex, local.az.firewall.name_unique)) > 0 : null
     }
     firewall_application_rule_collection = {
       valid_name        = length(regexall(local.az.firewall_application_rule_collection.regex, local.az.firewall_application_rule_collection.name)) > 0 && length(local.az.firewall_application_rule_collection.name) > local.az.firewall_application_rule_collection.min_length
-      valid_name_unique = length(regexall(local.az.firewall_application_rule_collection.regex, local.az.firewall_application_rule_collection.name_unique)) > 0
+      valid_name_unique = local.az.firewall_application_rule_collection.name_unique != null ? length(regexall(local.az.firewall_application_rule_collection.regex, local.az.firewall_application_rule_collection.name_unique)) > 0 : null
     }
     firewall_ip_configuration = {
       valid_name        = length(regexall(local.az.firewall_ip_configuration.regex, local.az.firewall_ip_configuration.name)) > 0 && length(local.az.firewall_ip_configuration.name) > local.az.firewall_ip_configuration.min_length
-      valid_name_unique = length(regexall(local.az.firewall_ip_configuration.regex, local.az.firewall_ip_configuration.name_unique)) > 0
+      valid_name_unique = local.az.firewall_ip_configuration.name_unique != null ? length(regexall(local.az.firewall_ip_configuration.regex, local.az.firewall_ip_configuration.name_unique)) > 0 : null
     }
     firewall_nat_rule_collection = {
       valid_name        = length(regexall(local.az.firewall_nat_rule_collection.regex, local.az.firewall_nat_rule_collection.name)) > 0 && length(local.az.firewall_nat_rule_collection.name) > local.az.firewall_nat_rule_collection.min_length
-      valid_name_unique = length(regexall(local.az.firewall_nat_rule_collection.regex, local.az.firewall_nat_rule_collection.name_unique)) > 0
+      valid_name_unique = local.az.firewall_nat_rule_collection.name_unique != null ? length(regexall(local.az.firewall_nat_rule_collection.regex, local.az.firewall_nat_rule_collection.name_unique)) > 0 : null
     }
     firewall_network_rule_collection = {
       valid_name        = length(regexall(local.az.firewall_network_rule_collection.regex, local.az.firewall_network_rule_collection.name)) > 0 && length(local.az.firewall_network_rule_collection.name) > local.az.firewall_network_rule_collection.min_length
-      valid_name_unique = length(regexall(local.az.firewall_network_rule_collection.regex, local.az.firewall_network_rule_collection.name_unique)) > 0
+      valid_name_unique = local.az.firewall_network_rule_collection.name_unique != null ? length(regexall(local.az.firewall_network_rule_collection.regex, local.az.firewall_network_rule_collection.name_unique)) > 0 : null
     }
     firewall_policy = {
       valid_name        = length(regexall(local.az.firewall_policy.regex, local.az.firewall_policy.name)) > 0 && length(local.az.firewall_policy.name) > local.az.firewall_policy.min_length
-      valid_name_unique = length(regexall(local.az.firewall_policy.regex, local.az.firewall_policy.name_unique)) > 0
+      valid_name_unique = local.az.firewall_policy.name_unique != null ? length(regexall(local.az.firewall_policy.regex, local.az.firewall_policy.name_unique)) > 0 : null
     }
     firewall_policy_rule_collection_group = {
       valid_name        = length(regexall(local.az.firewall_policy_rule_collection_group.regex, local.az.firewall_policy_rule_collection_group.name)) > 0 && length(local.az.firewall_policy_rule_collection_group.name) > local.az.firewall_policy_rule_collection_group.min_length
-      valid_name_unique = length(regexall(local.az.firewall_policy_rule_collection_group.regex, local.az.firewall_policy_rule_collection_group.name_unique)) > 0
+      valid_name_unique = local.az.firewall_policy_rule_collection_group.name_unique != null ? length(regexall(local.az.firewall_policy_rule_collection_group.regex, local.az.firewall_policy_rule_collection_group.name_unique)) > 0 : null
     }
     frontdoor = {
       valid_name        = length(regexall(local.az.frontdoor.regex, local.az.frontdoor.name)) > 0 && length(local.az.frontdoor.name) > local.az.frontdoor.min_length
-      valid_name_unique = length(regexall(local.az.frontdoor.regex, local.az.frontdoor.name_unique)) > 0
+      valid_name_unique = local.az.frontdoor.name_unique != null ? length(regexall(local.az.frontdoor.regex, local.az.frontdoor.name_unique)) > 0 : null
     }
     frontdoor_firewall_policy = {
       valid_name        = length(regexall(local.az.frontdoor_firewall_policy.regex, local.az.frontdoor_firewall_policy.name)) > 0 && length(local.az.frontdoor_firewall_policy.name) > local.az.frontdoor_firewall_policy.min_length
-      valid_name_unique = length(regexall(local.az.frontdoor_firewall_policy.regex, local.az.frontdoor_firewall_policy.name_unique)) > 0
+      valid_name_unique = local.az.frontdoor_firewall_policy.name_unique != null ? length(regexall(local.az.frontdoor_firewall_policy.regex, local.az.frontdoor_firewall_policy.name_unique)) > 0 : null
     }
     function_app = {
       valid_name        = length(regexall(local.az.function_app.regex, local.az.function_app.name)) > 0 && length(local.az.function_app.name) > local.az.function_app.min_length
-      valid_name_unique = length(regexall(local.az.function_app.regex, local.az.function_app.name_unique)) > 0
+      valid_name_unique = local.az.function_app.name_unique != null ? length(regexall(local.az.function_app.regex, local.az.function_app.name_unique)) > 0 : null
     }
     hdinsight_hadoop_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_hadoop_cluster.regex, local.az.hdinsight_hadoop_cluster.name)) > 0 && length(local.az.hdinsight_hadoop_cluster.name) > local.az.hdinsight_hadoop_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_hadoop_cluster.regex, local.az.hdinsight_hadoop_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_hadoop_cluster.name_unique != null ? length(regexall(local.az.hdinsight_hadoop_cluster.regex, local.az.hdinsight_hadoop_cluster.name_unique)) > 0 : null
     }
     hdinsight_hbase_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_hbase_cluster.regex, local.az.hdinsight_hbase_cluster.name)) > 0 && length(local.az.hdinsight_hbase_cluster.name) > local.az.hdinsight_hbase_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_hbase_cluster.regex, local.az.hdinsight_hbase_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_hbase_cluster.name_unique != null ? length(regexall(local.az.hdinsight_hbase_cluster.regex, local.az.hdinsight_hbase_cluster.name_unique)) > 0 : null
     }
     hdinsight_interactive_query_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_interactive_query_cluster.regex, local.az.hdinsight_interactive_query_cluster.name)) > 0 && length(local.az.hdinsight_interactive_query_cluster.name) > local.az.hdinsight_interactive_query_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_interactive_query_cluster.regex, local.az.hdinsight_interactive_query_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_interactive_query_cluster.name_unique != null ? length(regexall(local.az.hdinsight_interactive_query_cluster.regex, local.az.hdinsight_interactive_query_cluster.name_unique)) > 0 : null
     }
     hdinsight_kafka_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_kafka_cluster.regex, local.az.hdinsight_kafka_cluster.name)) > 0 && length(local.az.hdinsight_kafka_cluster.name) > local.az.hdinsight_kafka_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_kafka_cluster.regex, local.az.hdinsight_kafka_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_kafka_cluster.name_unique != null ? length(regexall(local.az.hdinsight_kafka_cluster.regex, local.az.hdinsight_kafka_cluster.name_unique)) > 0 : null
     }
     hdinsight_ml_services_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_ml_services_cluster.regex, local.az.hdinsight_ml_services_cluster.name)) > 0 && length(local.az.hdinsight_ml_services_cluster.name) > local.az.hdinsight_ml_services_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_ml_services_cluster.regex, local.az.hdinsight_ml_services_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_ml_services_cluster.name_unique != null ? length(regexall(local.az.hdinsight_ml_services_cluster.regex, local.az.hdinsight_ml_services_cluster.name_unique)) > 0 : null
     }
     hdinsight_rserver_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_rserver_cluster.regex, local.az.hdinsight_rserver_cluster.name)) > 0 && length(local.az.hdinsight_rserver_cluster.name) > local.az.hdinsight_rserver_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_rserver_cluster.regex, local.az.hdinsight_rserver_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_rserver_cluster.name_unique != null ? length(regexall(local.az.hdinsight_rserver_cluster.regex, local.az.hdinsight_rserver_cluster.name_unique)) > 0 : null
     }
     hdinsight_spark_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_spark_cluster.regex, local.az.hdinsight_spark_cluster.name)) > 0 && length(local.az.hdinsight_spark_cluster.name) > local.az.hdinsight_spark_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_spark_cluster.regex, local.az.hdinsight_spark_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_spark_cluster.name_unique != null ? length(regexall(local.az.hdinsight_spark_cluster.regex, local.az.hdinsight_spark_cluster.name_unique)) > 0 : null
     }
     hdinsight_storm_cluster = {
       valid_name        = length(regexall(local.az.hdinsight_storm_cluster.regex, local.az.hdinsight_storm_cluster.name)) > 0 && length(local.az.hdinsight_storm_cluster.name) > local.az.hdinsight_storm_cluster.min_length
-      valid_name_unique = length(regexall(local.az.hdinsight_storm_cluster.regex, local.az.hdinsight_storm_cluster.name_unique)) > 0
+      valid_name_unique = local.az.hdinsight_storm_cluster.name_unique != null ? length(regexall(local.az.hdinsight_storm_cluster.regex, local.az.hdinsight_storm_cluster.name_unique)) > 0 : null
     }
     image = {
       valid_name        = length(regexall(local.az.image.regex, local.az.image.name)) > 0 && length(local.az.image.name) > local.az.image.min_length
-      valid_name_unique = length(regexall(local.az.image.regex, local.az.image.name_unique)) > 0
+      valid_name_unique = local.az.image.name_unique != null ? length(regexall(local.az.image.regex, local.az.image.name_unique)) > 0 : null
     }
     iotcentral_application = {
       valid_name        = length(regexall(local.az.iotcentral_application.regex, local.az.iotcentral_application.name)) > 0 && length(local.az.iotcentral_application.name) > local.az.iotcentral_application.min_length
-      valid_name_unique = length(regexall(local.az.iotcentral_application.regex, local.az.iotcentral_application.name_unique)) > 0
+      valid_name_unique = local.az.iotcentral_application.name_unique != null ? length(regexall(local.az.iotcentral_application.regex, local.az.iotcentral_application.name_unique)) > 0 : null
     }
     iothub = {
       valid_name        = length(regexall(local.az.iothub.regex, local.az.iothub.name)) > 0 && length(local.az.iothub.name) > local.az.iothub.min_length
-      valid_name_unique = length(regexall(local.az.iothub.regex, local.az.iothub.name_unique)) > 0
+      valid_name_unique = local.az.iothub.name_unique != null ? length(regexall(local.az.iothub.regex, local.az.iothub.name_unique)) > 0 : null
     }
     iothub_consumer_group = {
       valid_name        = length(regexall(local.az.iothub_consumer_group.regex, local.az.iothub_consumer_group.name)) > 0 && length(local.az.iothub_consumer_group.name) > local.az.iothub_consumer_group.min_length
-      valid_name_unique = length(regexall(local.az.iothub_consumer_group.regex, local.az.iothub_consumer_group.name_unique)) > 0
+      valid_name_unique = local.az.iothub_consumer_group.name_unique != null ? length(regexall(local.az.iothub_consumer_group.regex, local.az.iothub_consumer_group.name_unique)) > 0 : null
     }
     iothub_dps = {
       valid_name        = length(regexall(local.az.iothub_dps.regex, local.az.iothub_dps.name)) > 0 && length(local.az.iothub_dps.name) > local.az.iothub_dps.min_length
-      valid_name_unique = length(regexall(local.az.iothub_dps.regex, local.az.iothub_dps.name_unique)) > 0
+      valid_name_unique = local.az.iothub_dps.name_unique != null ? length(regexall(local.az.iothub_dps.regex, local.az.iothub_dps.name_unique)) > 0 : null
     }
     iothub_dps_certificate = {
       valid_name        = length(regexall(local.az.iothub_dps_certificate.regex, local.az.iothub_dps_certificate.name)) > 0 && length(local.az.iothub_dps_certificate.name) > local.az.iothub_dps_certificate.min_length
-      valid_name_unique = length(regexall(local.az.iothub_dps_certificate.regex, local.az.iothub_dps_certificate.name_unique)) > 0
+      valid_name_unique = local.az.iothub_dps_certificate.name_unique != null ? length(regexall(local.az.iothub_dps_certificate.regex, local.az.iothub_dps_certificate.name_unique)) > 0 : null
     }
     ip_group = {
       valid_name        = length(regexall(local.az.ip_group.regex, local.az.ip_group.name)) > 0 && length(local.az.ip_group.name) > local.az.ip_group.min_length
-      valid_name_unique = length(regexall(local.az.ip_group.regex, local.az.ip_group.name_unique)) > 0
+      valid_name_unique = local.az.ip_group.name_unique != null ? length(regexall(local.az.ip_group.regex, local.az.ip_group.name_unique)) > 0 : null
     }
     key_vault = {
       valid_name        = length(regexall(local.az.key_vault.regex, local.az.key_vault.name)) > 0 && length(local.az.key_vault.name) > local.az.key_vault.min_length
-      valid_name_unique = length(regexall(local.az.key_vault.regex, local.az.key_vault.name_unique)) > 0
+      valid_name_unique = local.az.key_vault.name_unique != null ? length(regexall(local.az.key_vault.regex, local.az.key_vault.name_unique)) > 0 : null
     }
     key_vault_certificate = {
       valid_name        = length(regexall(local.az.key_vault_certificate.regex, local.az.key_vault_certificate.name)) > 0 && length(local.az.key_vault_certificate.name) > local.az.key_vault_certificate.min_length
-      valid_name_unique = length(regexall(local.az.key_vault_certificate.regex, local.az.key_vault_certificate.name_unique)) > 0
+      valid_name_unique = local.az.key_vault_certificate.name_unique != null ? length(regexall(local.az.key_vault_certificate.regex, local.az.key_vault_certificate.name_unique)) > 0 : null
     }
     key_vault_key = {
       valid_name        = length(regexall(local.az.key_vault_key.regex, local.az.key_vault_key.name)) > 0 && length(local.az.key_vault_key.name) > local.az.key_vault_key.min_length
-      valid_name_unique = length(regexall(local.az.key_vault_key.regex, local.az.key_vault_key.name_unique)) > 0
+      valid_name_unique = local.az.key_vault_key.name_unique != null ? length(regexall(local.az.key_vault_key.regex, local.az.key_vault_key.name_unique)) > 0 : null
     }
     key_vault_secret = {
       valid_name        = length(regexall(local.az.key_vault_secret.regex, local.az.key_vault_secret.name)) > 0 && length(local.az.key_vault_secret.name) > local.az.key_vault_secret.min_length
-      valid_name_unique = length(regexall(local.az.key_vault_secret.regex, local.az.key_vault_secret.name_unique)) > 0
+      valid_name_unique = local.az.key_vault_secret.name_unique != null ? length(regexall(local.az.key_vault_secret.regex, local.az.key_vault_secret.name_unique)) > 0 : null
     }
     kubernetes_cluster = {
       valid_name        = length(regexall(local.az.kubernetes_cluster.regex, local.az.kubernetes_cluster.name)) > 0 && length(local.az.kubernetes_cluster.name) > local.az.kubernetes_cluster.min_length
-      valid_name_unique = length(regexall(local.az.kubernetes_cluster.regex, local.az.kubernetes_cluster.name_unique)) > 0
+      valid_name_unique = local.az.kubernetes_cluster.name_unique != null ? length(regexall(local.az.kubernetes_cluster.regex, local.az.kubernetes_cluster.name_unique)) > 0 : null
     }
     kusto_cluster = {
       valid_name        = length(regexall(local.az.kusto_cluster.regex, local.az.kusto_cluster.name)) > 0 && length(local.az.kusto_cluster.name) > local.az.kusto_cluster.min_length
-      valid_name_unique = length(regexall(local.az.kusto_cluster.regex, local.az.kusto_cluster.name_unique)) > 0
+      valid_name_unique = local.az.kusto_cluster.name_unique != null ? length(regexall(local.az.kusto_cluster.regex, local.az.kusto_cluster.name_unique)) > 0 : null
     }
     kusto_database = {
       valid_name        = length(regexall(local.az.kusto_database.regex, local.az.kusto_database.name)) > 0 && length(local.az.kusto_database.name) > local.az.kusto_database.min_length
-      valid_name_unique = length(regexall(local.az.kusto_database.regex, local.az.kusto_database.name_unique)) > 0
+      valid_name_unique = local.az.kusto_database.name_unique != null ? length(regexall(local.az.kusto_database.regex, local.az.kusto_database.name_unique)) > 0 : null
     }
     kusto_eventhub_data_connection = {
       valid_name        = length(regexall(local.az.kusto_eventhub_data_connection.regex, local.az.kusto_eventhub_data_connection.name)) > 0 && length(local.az.kusto_eventhub_data_connection.name) > local.az.kusto_eventhub_data_connection.min_length
-      valid_name_unique = length(regexall(local.az.kusto_eventhub_data_connection.regex, local.az.kusto_eventhub_data_connection.name_unique)) > 0
+      valid_name_unique = local.az.kusto_eventhub_data_connection.name_unique != null ? length(regexall(local.az.kusto_eventhub_data_connection.regex, local.az.kusto_eventhub_data_connection.name_unique)) > 0 : null
     }
     lb = {
       valid_name        = length(regexall(local.az.lb.regex, local.az.lb.name)) > 0 && length(local.az.lb.name) > local.az.lb.min_length
-      valid_name_unique = length(regexall(local.az.lb.regex, local.az.lb.name_unique)) > 0
+      valid_name_unique = local.az.lb.name_unique != null ? length(regexall(local.az.lb.regex, local.az.lb.name_unique)) > 0 : null
     }
     lb_nat_rule = {
       valid_name        = length(regexall(local.az.lb_nat_rule.regex, local.az.lb_nat_rule.name)) > 0 && length(local.az.lb_nat_rule.name) > local.az.lb_nat_rule.min_length
-      valid_name_unique = length(regexall(local.az.lb_nat_rule.regex, local.az.lb_nat_rule.name_unique)) > 0
+      valid_name_unique = local.az.lb_nat_rule.name_unique != null ? length(regexall(local.az.lb_nat_rule.regex, local.az.lb_nat_rule.name_unique)) > 0 : null
     }
     lb_rule = {
       valid_name        = length(regexall(local.az.lb_rule.regex, local.az.lb_rule.name)) > 0 && length(local.az.lb_rule.name) > local.az.lb_rule.min_length
-      valid_name_unique = length(regexall(local.az.lb_rule.regex, local.az.lb_rule.name_unique)) > 0
+      valid_name_unique = local.az.lb_rule.name_unique != null ? length(regexall(local.az.lb_rule.regex, local.az.lb_rule.name_unique)) > 0 : null
     }
     linux_virtual_machine = {
       valid_name        = length(regexall(local.az.linux_virtual_machine.regex, local.az.linux_virtual_machine.name)) > 0 && length(local.az.linux_virtual_machine.name) > local.az.linux_virtual_machine.min_length
-      valid_name_unique = length(regexall(local.az.linux_virtual_machine.regex, local.az.linux_virtual_machine.name_unique)) > 0
+      valid_name_unique = local.az.linux_virtual_machine.name_unique != null ? length(regexall(local.az.linux_virtual_machine.regex, local.az.linux_virtual_machine.name_unique)) > 0 : null
     }
     linux_virtual_machine_scale_set = {
       valid_name        = length(regexall(local.az.linux_virtual_machine_scale_set.regex, local.az.linux_virtual_machine_scale_set.name)) > 0 && length(local.az.linux_virtual_machine_scale_set.name) > local.az.linux_virtual_machine_scale_set.min_length
-      valid_name_unique = length(regexall(local.az.linux_virtual_machine_scale_set.regex, local.az.linux_virtual_machine_scale_set.name_unique)) > 0
+      valid_name_unique = local.az.linux_virtual_machine_scale_set.name_unique != null ? length(regexall(local.az.linux_virtual_machine_scale_set.regex, local.az.linux_virtual_machine_scale_set.name_unique)) > 0 : null
     }
     load_test = {
       valid_name        = length(regexall(local.az.load_test.regex, local.az.load_test.name)) > 0 && length(local.az.load_test.name) > local.az.load_test.min_length
-      valid_name_unique = length(regexall(local.az.load_test.regex, local.az.load_test.name_unique)) > 0
+      valid_name_unique = local.az.load_test.name_unique != null ? length(regexall(local.az.load_test.regex, local.az.load_test.name_unique)) > 0 : null
     }
     local_network_gateway = {
       valid_name        = length(regexall(local.az.local_network_gateway.regex, local.az.local_network_gateway.name)) > 0 && length(local.az.local_network_gateway.name) > local.az.local_network_gateway.min_length
-      valid_name_unique = length(regexall(local.az.local_network_gateway.regex, local.az.local_network_gateway.name_unique)) > 0
+      valid_name_unique = local.az.local_network_gateway.name_unique != null ? length(regexall(local.az.local_network_gateway.regex, local.az.local_network_gateway.name_unique)) > 0 : null
     }
     log_analytics_query_pack = {
       valid_name        = length(regexall(local.az.log_analytics_query_pack.regex, local.az.log_analytics_query_pack.name)) > 0 && length(local.az.log_analytics_query_pack.name) > local.az.log_analytics_query_pack.min_length
-      valid_name_unique = length(regexall(local.az.log_analytics_query_pack.regex, local.az.log_analytics_query_pack.name_unique)) > 0
+      valid_name_unique = local.az.log_analytics_query_pack.name_unique != null ? length(regexall(local.az.log_analytics_query_pack.regex, local.az.log_analytics_query_pack.name_unique)) > 0 : null
     }
     log_analytics_workspace = {
       valid_name        = length(regexall(local.az.log_analytics_workspace.regex, local.az.log_analytics_workspace.name)) > 0 && length(local.az.log_analytics_workspace.name) > local.az.log_analytics_workspace.min_length
-      valid_name_unique = length(regexall(local.az.log_analytics_workspace.regex, local.az.log_analytics_workspace.name_unique)) > 0
+      valid_name_unique = local.az.log_analytics_workspace.name_unique != null ? length(regexall(local.az.log_analytics_workspace.regex, local.az.log_analytics_workspace.name_unique)) > 0 : null
     }
     logic_app_integration_account = {
       valid_name        = length(regexall(local.az.logic_app_integration_account.regex, local.az.logic_app_integration_account.name)) > 0 && length(local.az.logic_app_integration_account.name) > local.az.logic_app_integration_account.min_length
-      valid_name_unique = length(regexall(local.az.logic_app_integration_account.regex, local.az.logic_app_integration_account.name_unique)) > 0
+      valid_name_unique = local.az.logic_app_integration_account.name_unique != null ? length(regexall(local.az.logic_app_integration_account.regex, local.az.logic_app_integration_account.name_unique)) > 0 : null
     }
     logic_app_workflow = {
       valid_name        = length(regexall(local.az.logic_app_workflow.regex, local.az.logic_app_workflow.name)) > 0 && length(local.az.logic_app_workflow.name) > local.az.logic_app_workflow.min_length
-      valid_name_unique = length(regexall(local.az.logic_app_workflow.regex, local.az.logic_app_workflow.name_unique)) > 0
+      valid_name_unique = local.az.logic_app_workflow.name_unique != null ? length(regexall(local.az.logic_app_workflow.regex, local.az.logic_app_workflow.name_unique)) > 0 : null
     }
     machine_learning_registry = {
       valid_name        = length(regexall(local.az.machine_learning_registry.regex, local.az.machine_learning_registry.name)) > 0 && length(local.az.machine_learning_registry.name) > local.az.machine_learning_registry.min_length
-      valid_name_unique = length(regexall(local.az.machine_learning_registry.regex, local.az.machine_learning_registry.name_unique)) > 0
+      valid_name_unique = local.az.machine_learning_registry.name_unique != null ? length(regexall(local.az.machine_learning_registry.regex, local.az.machine_learning_registry.name_unique)) > 0 : null
     }
     machine_learning_workspace = {
       valid_name        = length(regexall(local.az.machine_learning_workspace.regex, local.az.machine_learning_workspace.name)) > 0 && length(local.az.machine_learning_workspace.name) > local.az.machine_learning_workspace.min_length
-      valid_name_unique = length(regexall(local.az.machine_learning_workspace.regex, local.az.machine_learning_workspace.name_unique)) > 0
+      valid_name_unique = local.az.machine_learning_workspace.name_unique != null ? length(regexall(local.az.machine_learning_workspace.regex, local.az.machine_learning_workspace.name_unique)) > 0 : null
     }
     maintenance_configuration = {
       valid_name        = length(regexall(local.az.maintenance_configuration.regex, local.az.maintenance_configuration.name)) > 0 && length(local.az.maintenance_configuration.name) > local.az.maintenance_configuration.min_length
-      valid_name_unique = length(regexall(local.az.maintenance_configuration.regex, local.az.maintenance_configuration.name_unique)) > 0
+      valid_name_unique = local.az.maintenance_configuration.name_unique != null ? length(regexall(local.az.maintenance_configuration.regex, local.az.maintenance_configuration.name_unique)) > 0 : null
     }
     managed_disk = {
       valid_name        = length(regexall(local.az.managed_disk.regex, local.az.managed_disk.name)) > 0 && length(local.az.managed_disk.name) > local.az.managed_disk.min_length
-      valid_name_unique = length(regexall(local.az.managed_disk.regex, local.az.managed_disk.name_unique)) > 0
+      valid_name_unique = local.az.managed_disk.name_unique != null ? length(regexall(local.az.managed_disk.regex, local.az.managed_disk.name_unique)) > 0 : null
     }
     management_group = {
       valid_name        = length(regexall(local.az.management_group.regex, local.az.management_group.name)) > 0 && length(local.az.management_group.name) > local.az.management_group.min_length
-      valid_name_unique = length(regexall(local.az.management_group.regex, local.az.management_group.name_unique)) > 0
+      valid_name_unique = local.az.management_group.name_unique != null ? length(regexall(local.az.management_group.regex, local.az.management_group.name_unique)) > 0 : null
     }
     maps_account = {
       valid_name        = length(regexall(local.az.maps_account.regex, local.az.maps_account.name)) > 0 && length(local.az.maps_account.name) > local.az.maps_account.min_length
-      valid_name_unique = length(regexall(local.az.maps_account.regex, local.az.maps_account.name_unique)) > 0
+      valid_name_unique = local.az.maps_account.name_unique != null ? length(regexall(local.az.maps_account.regex, local.az.maps_account.name_unique)) > 0 : null
     }
     mariadb_database = {
       valid_name        = length(regexall(local.az.mariadb_database.regex, local.az.mariadb_database.name)) > 0 && length(local.az.mariadb_database.name) > local.az.mariadb_database.min_length
-      valid_name_unique = length(regexall(local.az.mariadb_database.regex, local.az.mariadb_database.name_unique)) > 0
+      valid_name_unique = local.az.mariadb_database.name_unique != null ? length(regexall(local.az.mariadb_database.regex, local.az.mariadb_database.name_unique)) > 0 : null
     }
     mariadb_firewall_rule = {
       valid_name        = length(regexall(local.az.mariadb_firewall_rule.regex, local.az.mariadb_firewall_rule.name)) > 0 && length(local.az.mariadb_firewall_rule.name) > local.az.mariadb_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.mariadb_firewall_rule.regex, local.az.mariadb_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.mariadb_firewall_rule.name_unique != null ? length(regexall(local.az.mariadb_firewall_rule.regex, local.az.mariadb_firewall_rule.name_unique)) > 0 : null
     }
     mariadb_server = {
       valid_name        = length(regexall(local.az.mariadb_server.regex, local.az.mariadb_server.name)) > 0 && length(local.az.mariadb_server.name) > local.az.mariadb_server.min_length
-      valid_name_unique = length(regexall(local.az.mariadb_server.regex, local.az.mariadb_server.name_unique)) > 0
+      valid_name_unique = local.az.mariadb_server.name_unique != null ? length(regexall(local.az.mariadb_server.regex, local.az.mariadb_server.name_unique)) > 0 : null
     }
     mariadb_virtual_network_rule = {
       valid_name        = length(regexall(local.az.mariadb_virtual_network_rule.regex, local.az.mariadb_virtual_network_rule.name)) > 0 && length(local.az.mariadb_virtual_network_rule.name) > local.az.mariadb_virtual_network_rule.min_length
-      valid_name_unique = length(regexall(local.az.mariadb_virtual_network_rule.regex, local.az.mariadb_virtual_network_rule.name_unique)) > 0
+      valid_name_unique = local.az.mariadb_virtual_network_rule.name_unique != null ? length(regexall(local.az.mariadb_virtual_network_rule.regex, local.az.mariadb_virtual_network_rule.name_unique)) > 0 : null
     }
     monitor_action_group = {
       valid_name        = length(regexall(local.az.monitor_action_group.regex, local.az.monitor_action_group.name)) > 0 && length(local.az.monitor_action_group.name) > local.az.monitor_action_group.min_length
-      valid_name_unique = length(regexall(local.az.monitor_action_group.regex, local.az.monitor_action_group.name_unique)) > 0
+      valid_name_unique = local.az.monitor_action_group.name_unique != null ? length(regexall(local.az.monitor_action_group.regex, local.az.monitor_action_group.name_unique)) > 0 : null
     }
     monitor_alert_processing_rule_action_group = {
       valid_name        = length(regexall(local.az.monitor_alert_processing_rule_action_group.regex, local.az.monitor_alert_processing_rule_action_group.name)) > 0 && length(local.az.monitor_alert_processing_rule_action_group.name) > local.az.monitor_alert_processing_rule_action_group.min_length
-      valid_name_unique = length(regexall(local.az.monitor_alert_processing_rule_action_group.regex, local.az.monitor_alert_processing_rule_action_group.name_unique)) > 0
+      valid_name_unique = local.az.monitor_alert_processing_rule_action_group.name_unique != null ? length(regexall(local.az.monitor_alert_processing_rule_action_group.regex, local.az.monitor_alert_processing_rule_action_group.name_unique)) > 0 : null
     }
     monitor_autoscale_setting = {
       valid_name        = length(regexall(local.az.monitor_autoscale_setting.regex, local.az.monitor_autoscale_setting.name)) > 0 && length(local.az.monitor_autoscale_setting.name) > local.az.monitor_autoscale_setting.min_length
-      valid_name_unique = length(regexall(local.az.monitor_autoscale_setting.regex, local.az.monitor_autoscale_setting.name_unique)) > 0
+      valid_name_unique = local.az.monitor_autoscale_setting.name_unique != null ? length(regexall(local.az.monitor_autoscale_setting.regex, local.az.monitor_autoscale_setting.name_unique)) > 0 : null
     }
     monitor_data_collection_endpoint = {
       valid_name        = length(regexall(local.az.monitor_data_collection_endpoint.regex, local.az.monitor_data_collection_endpoint.name)) > 0 && length(local.az.monitor_data_collection_endpoint.name) > local.az.monitor_data_collection_endpoint.min_length
-      valid_name_unique = length(regexall(local.az.monitor_data_collection_endpoint.regex, local.az.monitor_data_collection_endpoint.name_unique)) > 0
+      valid_name_unique = local.az.monitor_data_collection_endpoint.name_unique != null ? length(regexall(local.az.monitor_data_collection_endpoint.regex, local.az.monitor_data_collection_endpoint.name_unique)) > 0 : null
     }
     monitor_data_collection_rule = {
       valid_name        = length(regexall(local.az.monitor_data_collection_rule.regex, local.az.monitor_data_collection_rule.name)) > 0 && length(local.az.monitor_data_collection_rule.name) > local.az.monitor_data_collection_rule.min_length
-      valid_name_unique = length(regexall(local.az.monitor_data_collection_rule.regex, local.az.monitor_data_collection_rule.name_unique)) > 0
+      valid_name_unique = local.az.monitor_data_collection_rule.name_unique != null ? length(regexall(local.az.monitor_data_collection_rule.regex, local.az.monitor_data_collection_rule.name_unique)) > 0 : null
     }
     monitor_diagnostic_setting = {
       valid_name        = length(regexall(local.az.monitor_diagnostic_setting.regex, local.az.monitor_diagnostic_setting.name)) > 0 && length(local.az.monitor_diagnostic_setting.name) > local.az.monitor_diagnostic_setting.min_length
-      valid_name_unique = length(regexall(local.az.monitor_diagnostic_setting.regex, local.az.monitor_diagnostic_setting.name_unique)) > 0
+      valid_name_unique = local.az.monitor_diagnostic_setting.name_unique != null ? length(regexall(local.az.monitor_diagnostic_setting.regex, local.az.monitor_diagnostic_setting.name_unique)) > 0 : null
     }
     monitor_scheduled_query_rules_alert = {
       valid_name        = length(regexall(local.az.monitor_scheduled_query_rules_alert.regex, local.az.monitor_scheduled_query_rules_alert.name)) > 0 && length(local.az.monitor_scheduled_query_rules_alert.name) > local.az.monitor_scheduled_query_rules_alert.min_length
-      valid_name_unique = length(regexall(local.az.monitor_scheduled_query_rules_alert.regex, local.az.monitor_scheduled_query_rules_alert.name_unique)) > 0
+      valid_name_unique = local.az.monitor_scheduled_query_rules_alert.name_unique != null ? length(regexall(local.az.monitor_scheduled_query_rules_alert.regex, local.az.monitor_scheduled_query_rules_alert.name_unique)) > 0 : null
     }
     mssql_database = {
       valid_name        = length(regexall(local.az.mssql_database.regex, local.az.mssql_database.name)) > 0 && length(local.az.mssql_database.name) > local.az.mssql_database.min_length
-      valid_name_unique = length(regexall(local.az.mssql_database.regex, local.az.mssql_database.name_unique)) > 0
+      valid_name_unique = local.az.mssql_database.name_unique != null ? length(regexall(local.az.mssql_database.regex, local.az.mssql_database.name_unique)) > 0 : null
     }
     mssql_elasticpool = {
       valid_name        = length(regexall(local.az.mssql_elasticpool.regex, local.az.mssql_elasticpool.name)) > 0 && length(local.az.mssql_elasticpool.name) > local.az.mssql_elasticpool.min_length
-      valid_name_unique = length(regexall(local.az.mssql_elasticpool.regex, local.az.mssql_elasticpool.name_unique)) > 0
+      valid_name_unique = local.az.mssql_elasticpool.name_unique != null ? length(regexall(local.az.mssql_elasticpool.regex, local.az.mssql_elasticpool.name_unique)) > 0 : null
     }
     mssql_job_agent = {
       valid_name        = length(regexall(local.az.mssql_job_agent.regex, local.az.mssql_job_agent.name)) > 0 && length(local.az.mssql_job_agent.name) > local.az.mssql_job_agent.min_length
-      valid_name_unique = length(regexall(local.az.mssql_job_agent.regex, local.az.mssql_job_agent.name_unique)) > 0
+      valid_name_unique = local.az.mssql_job_agent.name_unique != null ? length(regexall(local.az.mssql_job_agent.regex, local.az.mssql_job_agent.name_unique)) > 0 : null
     }
     mssql_managed_instance = {
       valid_name        = length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name)) > 0 && length(local.az.mssql_managed_instance.name) > local.az.mssql_managed_instance.min_length
-      valid_name_unique = length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name_unique)) > 0
+      valid_name_unique = local.az.mssql_managed_instance.name_unique != null ? length(regexall(local.az.mssql_managed_instance.regex, local.az.mssql_managed_instance.name_unique)) > 0 : null
     }
     mssql_server = {
       valid_name        = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name)) > 0 && length(local.az.mssql_server.name) > local.az.mssql_server.min_length
-      valid_name_unique = length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name_unique)) > 0
+      valid_name_unique = local.az.mssql_server.name_unique != null ? length(regexall(local.az.mssql_server.regex, local.az.mssql_server.name_unique)) > 0 : null
     }
     mysql_database = {
       valid_name        = length(regexall(local.az.mysql_database.regex, local.az.mysql_database.name)) > 0 && length(local.az.mysql_database.name) > local.az.mysql_database.min_length
-      valid_name_unique = length(regexall(local.az.mysql_database.regex, local.az.mysql_database.name_unique)) > 0
+      valid_name_unique = local.az.mysql_database.name_unique != null ? length(regexall(local.az.mysql_database.regex, local.az.mysql_database.name_unique)) > 0 : null
     }
     mysql_firewall_rule = {
       valid_name        = length(regexall(local.az.mysql_firewall_rule.regex, local.az.mysql_firewall_rule.name)) > 0 && length(local.az.mysql_firewall_rule.name) > local.az.mysql_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.mysql_firewall_rule.regex, local.az.mysql_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.mysql_firewall_rule.name_unique != null ? length(regexall(local.az.mysql_firewall_rule.regex, local.az.mysql_firewall_rule.name_unique)) > 0 : null
     }
     mysql_server = {
       valid_name        = length(regexall(local.az.mysql_server.regex, local.az.mysql_server.name)) > 0 && length(local.az.mysql_server.name) > local.az.mysql_server.min_length
-      valid_name_unique = length(regexall(local.az.mysql_server.regex, local.az.mysql_server.name_unique)) > 0
+      valid_name_unique = local.az.mysql_server.name_unique != null ? length(regexall(local.az.mysql_server.regex, local.az.mysql_server.name_unique)) > 0 : null
     }
     mysql_virtual_network_rule = {
       valid_name        = length(regexall(local.az.mysql_virtual_network_rule.regex, local.az.mysql_virtual_network_rule.name)) > 0 && length(local.az.mysql_virtual_network_rule.name) > local.az.mysql_virtual_network_rule.min_length
-      valid_name_unique = length(regexall(local.az.mysql_virtual_network_rule.regex, local.az.mysql_virtual_network_rule.name_unique)) > 0
+      valid_name_unique = local.az.mysql_virtual_network_rule.name_unique != null ? length(regexall(local.az.mysql_virtual_network_rule.regex, local.az.mysql_virtual_network_rule.name_unique)) > 0 : null
     }
     nat_gateway = {
       valid_name        = length(regexall(local.az.nat_gateway.regex, local.az.nat_gateway.name)) > 0 && length(local.az.nat_gateway.name) > local.az.nat_gateway.min_length
-      valid_name_unique = length(regexall(local.az.nat_gateway.regex, local.az.nat_gateway.name_unique)) > 0
+      valid_name_unique = local.az.nat_gateway.name_unique != null ? length(regexall(local.az.nat_gateway.regex, local.az.nat_gateway.name_unique)) > 0 : null
     }
     network_ddos_protection_plan = {
       valid_name        = length(regexall(local.az.network_ddos_protection_plan.regex, local.az.network_ddos_protection_plan.name)) > 0 && length(local.az.network_ddos_protection_plan.name) > local.az.network_ddos_protection_plan.min_length
-      valid_name_unique = length(regexall(local.az.network_ddos_protection_plan.regex, local.az.network_ddos_protection_plan.name_unique)) > 0
+      valid_name_unique = local.az.network_ddos_protection_plan.name_unique != null ? length(regexall(local.az.network_ddos_protection_plan.regex, local.az.network_ddos_protection_plan.name_unique)) > 0 : null
     }
     network_interface = {
       valid_name        = length(regexall(local.az.network_interface.regex, local.az.network_interface.name)) > 0 && length(local.az.network_interface.name) > local.az.network_interface.min_length
-      valid_name_unique = length(regexall(local.az.network_interface.regex, local.az.network_interface.name_unique)) > 0
+      valid_name_unique = local.az.network_interface.name_unique != null ? length(regexall(local.az.network_interface.regex, local.az.network_interface.name_unique)) > 0 : null
     }
     network_manager = {
       valid_name        = length(regexall(local.az.network_manager.regex, local.az.network_manager.name)) > 0 && length(local.az.network_manager.name) > local.az.network_manager.min_length
-      valid_name_unique = length(regexall(local.az.network_manager.regex, local.az.network_manager.name_unique)) > 0
+      valid_name_unique = local.az.network_manager.name_unique != null ? length(regexall(local.az.network_manager.regex, local.az.network_manager.name_unique)) > 0 : null
     }
     network_security_group = {
       valid_name        = length(regexall(local.az.network_security_group.regex, local.az.network_security_group.name)) > 0 && length(local.az.network_security_group.name) > local.az.network_security_group.min_length
-      valid_name_unique = length(regexall(local.az.network_security_group.regex, local.az.network_security_group.name_unique)) > 0
+      valid_name_unique = local.az.network_security_group.name_unique != null ? length(regexall(local.az.network_security_group.regex, local.az.network_security_group.name_unique)) > 0 : null
     }
     network_security_group_rule = {
       valid_name        = length(regexall(local.az.network_security_group_rule.regex, local.az.network_security_group_rule.name)) > 0 && length(local.az.network_security_group_rule.name) > local.az.network_security_group_rule.min_length
-      valid_name_unique = length(regexall(local.az.network_security_group_rule.regex, local.az.network_security_group_rule.name_unique)) > 0
+      valid_name_unique = local.az.network_security_group_rule.name_unique != null ? length(regexall(local.az.network_security_group_rule.regex, local.az.network_security_group_rule.name_unique)) > 0 : null
     }
     network_security_rule = {
       valid_name        = length(regexall(local.az.network_security_rule.regex, local.az.network_security_rule.name)) > 0 && length(local.az.network_security_rule.name) > local.az.network_security_rule.min_length
-      valid_name_unique = length(regexall(local.az.network_security_rule.regex, local.az.network_security_rule.name_unique)) > 0
+      valid_name_unique = local.az.network_security_rule.name_unique != null ? length(regexall(local.az.network_security_rule.regex, local.az.network_security_rule.name_unique)) > 0 : null
     }
     network_watcher = {
       valid_name        = length(regexall(local.az.network_watcher.regex, local.az.network_watcher.name)) > 0 && length(local.az.network_watcher.name) > local.az.network_watcher.min_length
-      valid_name_unique = length(regexall(local.az.network_watcher.regex, local.az.network_watcher.name_unique)) > 0
+      valid_name_unique = local.az.network_watcher.name_unique != null ? length(regexall(local.az.network_watcher.regex, local.az.network_watcher.name_unique)) > 0 : null
     }
     notification_hub = {
       valid_name        = length(regexall(local.az.notification_hub.regex, local.az.notification_hub.name)) > 0 && length(local.az.notification_hub.name) > local.az.notification_hub.min_length
-      valid_name_unique = length(regexall(local.az.notification_hub.regex, local.az.notification_hub.name_unique)) > 0
+      valid_name_unique = local.az.notification_hub.name_unique != null ? length(regexall(local.az.notification_hub.regex, local.az.notification_hub.name_unique)) > 0 : null
     }
     notification_hub_authorization_rule = {
       valid_name        = length(regexall(local.az.notification_hub_authorization_rule.regex, local.az.notification_hub_authorization_rule.name)) > 0 && length(local.az.notification_hub_authorization_rule.name) > local.az.notification_hub_authorization_rule.min_length
-      valid_name_unique = length(regexall(local.az.notification_hub_authorization_rule.regex, local.az.notification_hub_authorization_rule.name_unique)) > 0
+      valid_name_unique = local.az.notification_hub_authorization_rule.name_unique != null ? length(regexall(local.az.notification_hub_authorization_rule.regex, local.az.notification_hub_authorization_rule.name_unique)) > 0 : null
     }
     notification_hub_namespace = {
       valid_name        = length(regexall(local.az.notification_hub_namespace.regex, local.az.notification_hub_namespace.name)) > 0 && length(local.az.notification_hub_namespace.name) > local.az.notification_hub_namespace.min_length
-      valid_name_unique = length(regexall(local.az.notification_hub_namespace.regex, local.az.notification_hub_namespace.name_unique)) > 0
+      valid_name_unique = local.az.notification_hub_namespace.name_unique != null ? length(regexall(local.az.notification_hub_namespace.regex, local.az.notification_hub_namespace.name_unique)) > 0 : null
     }
     point_to_site_vpn_gateway = {
       valid_name        = length(regexall(local.az.point_to_site_vpn_gateway.regex, local.az.point_to_site_vpn_gateway.name)) > 0 && length(local.az.point_to_site_vpn_gateway.name) > local.az.point_to_site_vpn_gateway.min_length
-      valid_name_unique = length(regexall(local.az.point_to_site_vpn_gateway.regex, local.az.point_to_site_vpn_gateway.name_unique)) > 0
+      valid_name_unique = local.az.point_to_site_vpn_gateway.name_unique != null ? length(regexall(local.az.point_to_site_vpn_gateway.regex, local.az.point_to_site_vpn_gateway.name_unique)) > 0 : null
     }
     policy_definition = {
       valid_name        = length(regexall(local.az.policy_definition.regex, local.az.policy_definition.name)) > 0 && length(local.az.policy_definition.name) > local.az.policy_definition.min_length
-      valid_name_unique = length(regexall(local.az.policy_definition.regex, local.az.policy_definition.name_unique)) > 0
+      valid_name_unique = local.az.policy_definition.name_unique != null ? length(regexall(local.az.policy_definition.regex, local.az.policy_definition.name_unique)) > 0 : null
     }
     postgresql_database = {
       valid_name        = length(regexall(local.az.postgresql_database.regex, local.az.postgresql_database.name)) > 0 && length(local.az.postgresql_database.name) > local.az.postgresql_database.min_length
-      valid_name_unique = length(regexall(local.az.postgresql_database.regex, local.az.postgresql_database.name_unique)) > 0
+      valid_name_unique = local.az.postgresql_database.name_unique != null ? length(regexall(local.az.postgresql_database.regex, local.az.postgresql_database.name_unique)) > 0 : null
     }
     postgresql_firewall_rule = {
       valid_name        = length(regexall(local.az.postgresql_firewall_rule.regex, local.az.postgresql_firewall_rule.name)) > 0 && length(local.az.postgresql_firewall_rule.name) > local.az.postgresql_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.postgresql_firewall_rule.regex, local.az.postgresql_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.postgresql_firewall_rule.name_unique != null ? length(regexall(local.az.postgresql_firewall_rule.regex, local.az.postgresql_firewall_rule.name_unique)) > 0 : null
     }
     postgresql_server = {
       valid_name        = length(regexall(local.az.postgresql_server.regex, local.az.postgresql_server.name)) > 0 && length(local.az.postgresql_server.name) > local.az.postgresql_server.min_length
-      valid_name_unique = length(regexall(local.az.postgresql_server.regex, local.az.postgresql_server.name_unique)) > 0
+      valid_name_unique = local.az.postgresql_server.name_unique != null ? length(regexall(local.az.postgresql_server.regex, local.az.postgresql_server.name_unique)) > 0 : null
     }
     postgresql_virtual_network_rule = {
       valid_name        = length(regexall(local.az.postgresql_virtual_network_rule.regex, local.az.postgresql_virtual_network_rule.name)) > 0 && length(local.az.postgresql_virtual_network_rule.name) > local.az.postgresql_virtual_network_rule.min_length
-      valid_name_unique = length(regexall(local.az.postgresql_virtual_network_rule.regex, local.az.postgresql_virtual_network_rule.name_unique)) > 0
+      valid_name_unique = local.az.postgresql_virtual_network_rule.name_unique != null ? length(regexall(local.az.postgresql_virtual_network_rule.regex, local.az.postgresql_virtual_network_rule.name_unique)) > 0 : null
     }
     powerbi_embedded = {
       valid_name        = length(regexall(local.az.powerbi_embedded.regex, local.az.powerbi_embedded.name)) > 0 && length(local.az.powerbi_embedded.name) > local.az.powerbi_embedded.min_length
-      valid_name_unique = length(regexall(local.az.powerbi_embedded.regex, local.az.powerbi_embedded.name_unique)) > 0
+      valid_name_unique = local.az.powerbi_embedded.name_unique != null ? length(regexall(local.az.powerbi_embedded.regex, local.az.powerbi_embedded.name_unique)) > 0 : null
     }
     private_dns_a_record = {
       valid_name        = length(regexall(local.az.private_dns_a_record.regex, local.az.private_dns_a_record.name)) > 0 && length(local.az.private_dns_a_record.name) > local.az.private_dns_a_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_a_record.regex, local.az.private_dns_a_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_a_record.name_unique != null ? length(regexall(local.az.private_dns_a_record.regex, local.az.private_dns_a_record.name_unique)) > 0 : null
     }
     private_dns_aaaa_record = {
       valid_name        = length(regexall(local.az.private_dns_aaaa_record.regex, local.az.private_dns_aaaa_record.name)) > 0 && length(local.az.private_dns_aaaa_record.name) > local.az.private_dns_aaaa_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_aaaa_record.regex, local.az.private_dns_aaaa_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_aaaa_record.name_unique != null ? length(regexall(local.az.private_dns_aaaa_record.regex, local.az.private_dns_aaaa_record.name_unique)) > 0 : null
     }
     private_dns_cname_record = {
       valid_name        = length(regexall(local.az.private_dns_cname_record.regex, local.az.private_dns_cname_record.name)) > 0 && length(local.az.private_dns_cname_record.name) > local.az.private_dns_cname_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_cname_record.regex, local.az.private_dns_cname_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_cname_record.name_unique != null ? length(regexall(local.az.private_dns_cname_record.regex, local.az.private_dns_cname_record.name_unique)) > 0 : null
     }
     private_dns_mx_record = {
       valid_name        = length(regexall(local.az.private_dns_mx_record.regex, local.az.private_dns_mx_record.name)) > 0 && length(local.az.private_dns_mx_record.name) > local.az.private_dns_mx_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_mx_record.regex, local.az.private_dns_mx_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_mx_record.name_unique != null ? length(regexall(local.az.private_dns_mx_record.regex, local.az.private_dns_mx_record.name_unique)) > 0 : null
     }
     private_dns_ptr_record = {
       valid_name        = length(regexall(local.az.private_dns_ptr_record.regex, local.az.private_dns_ptr_record.name)) > 0 && length(local.az.private_dns_ptr_record.name) > local.az.private_dns_ptr_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_ptr_record.regex, local.az.private_dns_ptr_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_ptr_record.name_unique != null ? length(regexall(local.az.private_dns_ptr_record.regex, local.az.private_dns_ptr_record.name_unique)) > 0 : null
     }
     private_dns_srv_record = {
       valid_name        = length(regexall(local.az.private_dns_srv_record.regex, local.az.private_dns_srv_record.name)) > 0 && length(local.az.private_dns_srv_record.name) > local.az.private_dns_srv_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_srv_record.regex, local.az.private_dns_srv_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_srv_record.name_unique != null ? length(regexall(local.az.private_dns_srv_record.regex, local.az.private_dns_srv_record.name_unique)) > 0 : null
     }
     private_dns_txt_record = {
       valid_name        = length(regexall(local.az.private_dns_txt_record.regex, local.az.private_dns_txt_record.name)) > 0 && length(local.az.private_dns_txt_record.name) > local.az.private_dns_txt_record.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_txt_record.regex, local.az.private_dns_txt_record.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_txt_record.name_unique != null ? length(regexall(local.az.private_dns_txt_record.regex, local.az.private_dns_txt_record.name_unique)) > 0 : null
     }
     private_dns_zone = {
       valid_name        = length(regexall(local.az.private_dns_zone.regex, local.az.private_dns_zone.name)) > 0 && length(local.az.private_dns_zone.name) > local.az.private_dns_zone.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_zone.regex, local.az.private_dns_zone.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_zone.name_unique != null ? length(regexall(local.az.private_dns_zone.regex, local.az.private_dns_zone.name_unique)) > 0 : null
     }
     private_dns_zone_group = {
       valid_name        = length(regexall(local.az.private_dns_zone_group.regex, local.az.private_dns_zone_group.name)) > 0 && length(local.az.private_dns_zone_group.name) > local.az.private_dns_zone_group.min_length
-      valid_name_unique = length(regexall(local.az.private_dns_zone_group.regex, local.az.private_dns_zone_group.name_unique)) > 0
+      valid_name_unique = local.az.private_dns_zone_group.name_unique != null ? length(regexall(local.az.private_dns_zone_group.regex, local.az.private_dns_zone_group.name_unique)) > 0 : null
     }
     private_endpoint = {
       valid_name        = length(regexall(local.az.private_endpoint.regex, local.az.private_endpoint.name)) > 0 && length(local.az.private_endpoint.name) > local.az.private_endpoint.min_length
-      valid_name_unique = length(regexall(local.az.private_endpoint.regex, local.az.private_endpoint.name_unique)) > 0
+      valid_name_unique = local.az.private_endpoint.name_unique != null ? length(regexall(local.az.private_endpoint.regex, local.az.private_endpoint.name_unique)) > 0 : null
     }
     private_link_service = {
       valid_name        = length(regexall(local.az.private_link_service.regex, local.az.private_link_service.name)) > 0 && length(local.az.private_link_service.name) > local.az.private_link_service.min_length
-      valid_name_unique = length(regexall(local.az.private_link_service.regex, local.az.private_link_service.name_unique)) > 0
+      valid_name_unique = local.az.private_link_service.name_unique != null ? length(regexall(local.az.private_link_service.regex, local.az.private_link_service.name_unique)) > 0 : null
     }
     private_service_connection = {
       valid_name        = length(regexall(local.az.private_service_connection.regex, local.az.private_service_connection.name)) > 0 && length(local.az.private_service_connection.name) > local.az.private_service_connection.min_length
-      valid_name_unique = length(regexall(local.az.private_service_connection.regex, local.az.private_service_connection.name_unique)) > 0
+      valid_name_unique = local.az.private_service_connection.name_unique != null ? length(regexall(local.az.private_service_connection.regex, local.az.private_service_connection.name_unique)) > 0 : null
     }
     proximity_placement_group = {
       valid_name        = length(regexall(local.az.proximity_placement_group.regex, local.az.proximity_placement_group.name)) > 0 && length(local.az.proximity_placement_group.name) > local.az.proximity_placement_group.min_length
-      valid_name_unique = length(regexall(local.az.proximity_placement_group.regex, local.az.proximity_placement_group.name_unique)) > 0
+      valid_name_unique = local.az.proximity_placement_group.name_unique != null ? length(regexall(local.az.proximity_placement_group.regex, local.az.proximity_placement_group.name_unique)) > 0 : null
     }
     public_ip = {
       valid_name        = length(regexall(local.az.public_ip.regex, local.az.public_ip.name)) > 0 && length(local.az.public_ip.name) > local.az.public_ip.min_length
-      valid_name_unique = length(regexall(local.az.public_ip.regex, local.az.public_ip.name_unique)) > 0
+      valid_name_unique = local.az.public_ip.name_unique != null ? length(regexall(local.az.public_ip.regex, local.az.public_ip.name_unique)) > 0 : null
     }
     public_ip_prefix = {
       valid_name        = length(regexall(local.az.public_ip_prefix.regex, local.az.public_ip_prefix.name)) > 0 && length(local.az.public_ip_prefix.name) > local.az.public_ip_prefix.min_length
-      valid_name_unique = length(regexall(local.az.public_ip_prefix.regex, local.az.public_ip_prefix.name_unique)) > 0
+      valid_name_unique = local.az.public_ip_prefix.name_unique != null ? length(regexall(local.az.public_ip_prefix.regex, local.az.public_ip_prefix.name_unique)) > 0 : null
     }
     purview_account = {
       valid_name        = length(regexall(local.az.purview_account.regex, local.az.purview_account.name)) > 0 && length(local.az.purview_account.name) > local.az.purview_account.min_length
-      valid_name_unique = length(regexall(local.az.purview_account.regex, local.az.purview_account.name_unique)) > 0
+      valid_name_unique = local.az.purview_account.name_unique != null ? length(regexall(local.az.purview_account.regex, local.az.purview_account.name_unique)) > 0 : null
     }
     recovery_services_vault = {
       valid_name        = length(regexall(local.az.recovery_services_vault.regex, local.az.recovery_services_vault.name)) > 0 && length(local.az.recovery_services_vault.name) > local.az.recovery_services_vault.min_length
-      valid_name_unique = length(regexall(local.az.recovery_services_vault.regex, local.az.recovery_services_vault.name_unique)) > 0
+      valid_name_unique = local.az.recovery_services_vault.name_unique != null ? length(regexall(local.az.recovery_services_vault.regex, local.az.recovery_services_vault.name_unique)) > 0 : null
     }
     redhat_openshift_cluster = {
       valid_name        = length(regexall(local.az.redhat_openshift_cluster.regex, local.az.redhat_openshift_cluster.name)) > 0 && length(local.az.redhat_openshift_cluster.name) > local.az.redhat_openshift_cluster.min_length
-      valid_name_unique = length(regexall(local.az.redhat_openshift_cluster.regex, local.az.redhat_openshift_cluster.name_unique)) > 0
+      valid_name_unique = local.az.redhat_openshift_cluster.name_unique != null ? length(regexall(local.az.redhat_openshift_cluster.regex, local.az.redhat_openshift_cluster.name_unique)) > 0 : null
     }
     redis_cache = {
       valid_name        = length(regexall(local.az.redis_cache.regex, local.az.redis_cache.name)) > 0 && length(local.az.redis_cache.name) > local.az.redis_cache.min_length
-      valid_name_unique = length(regexall(local.az.redis_cache.regex, local.az.redis_cache.name_unique)) > 0
+      valid_name_unique = local.az.redis_cache.name_unique != null ? length(regexall(local.az.redis_cache.regex, local.az.redis_cache.name_unique)) > 0 : null
     }
     redis_firewall_rule = {
       valid_name        = length(regexall(local.az.redis_firewall_rule.regex, local.az.redis_firewall_rule.name)) > 0 && length(local.az.redis_firewall_rule.name) > local.az.redis_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.redis_firewall_rule.regex, local.az.redis_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.redis_firewall_rule.name_unique != null ? length(regexall(local.az.redis_firewall_rule.regex, local.az.redis_firewall_rule.name_unique)) > 0 : null
     }
     relay_hybrid_connection = {
       valid_name        = length(regexall(local.az.relay_hybrid_connection.regex, local.az.relay_hybrid_connection.name)) > 0 && length(local.az.relay_hybrid_connection.name) > local.az.relay_hybrid_connection.min_length
-      valid_name_unique = length(regexall(local.az.relay_hybrid_connection.regex, local.az.relay_hybrid_connection.name_unique)) > 0
+      valid_name_unique = local.az.relay_hybrid_connection.name_unique != null ? length(regexall(local.az.relay_hybrid_connection.regex, local.az.relay_hybrid_connection.name_unique)) > 0 : null
     }
     relay_namespace = {
       valid_name        = length(regexall(local.az.relay_namespace.regex, local.az.relay_namespace.name)) > 0 && length(local.az.relay_namespace.name) > local.az.relay_namespace.min_length
-      valid_name_unique = length(regexall(local.az.relay_namespace.regex, local.az.relay_namespace.name_unique)) > 0
+      valid_name_unique = local.az.relay_namespace.name_unique != null ? length(regexall(local.az.relay_namespace.regex, local.az.relay_namespace.name_unique)) > 0 : null
     }
     resource_group = {
       valid_name        = length(regexall(local.az.resource_group.regex, local.az.resource_group.name)) > 0 && length(local.az.resource_group.name) > local.az.resource_group.min_length
-      valid_name_unique = length(regexall(local.az.resource_group.regex, local.az.resource_group.name_unique)) > 0
+      valid_name_unique = local.az.resource_group.name_unique != null ? length(regexall(local.az.resource_group.regex, local.az.resource_group.name_unique)) > 0 : null
     }
     resource_group_template_deployment = {
       valid_name        = length(regexall(local.az.resource_group_template_deployment.regex, local.az.resource_group_template_deployment.name)) > 0 && length(local.az.resource_group_template_deployment.name) > local.az.resource_group_template_deployment.min_length
-      valid_name_unique = length(regexall(local.az.resource_group_template_deployment.regex, local.az.resource_group_template_deployment.name_unique)) > 0
+      valid_name_unique = local.az.resource_group_template_deployment.name_unique != null ? length(regexall(local.az.resource_group_template_deployment.regex, local.az.resource_group_template_deployment.name_unique)) > 0 : null
     }
     role_assignment = {
       valid_name        = length(regexall(local.az.role_assignment.regex, local.az.role_assignment.name)) > 0 && length(local.az.role_assignment.name) > local.az.role_assignment.min_length
-      valid_name_unique = length(regexall(local.az.role_assignment.regex, local.az.role_assignment.name_unique)) > 0
+      valid_name_unique = local.az.role_assignment.name_unique != null ? length(regexall(local.az.role_assignment.regex, local.az.role_assignment.name_unique)) > 0 : null
     }
     role_definition = {
       valid_name        = length(regexall(local.az.role_definition.regex, local.az.role_definition.name)) > 0 && length(local.az.role_definition.name) > local.az.role_definition.min_length
-      valid_name_unique = length(regexall(local.az.role_definition.regex, local.az.role_definition.name_unique)) > 0
+      valid_name_unique = local.az.role_definition.name_unique != null ? length(regexall(local.az.role_definition.regex, local.az.role_definition.name_unique)) > 0 : null
     }
     route = {
       valid_name        = length(regexall(local.az.route.regex, local.az.route.name)) > 0 && length(local.az.route.name) > local.az.route.min_length
-      valid_name_unique = length(regexall(local.az.route.regex, local.az.route.name_unique)) > 0
+      valid_name_unique = local.az.route.name_unique != null ? length(regexall(local.az.route.regex, local.az.route.name_unique)) > 0 : null
     }
     route_filter = {
       valid_name        = length(regexall(local.az.route_filter.regex, local.az.route_filter.name)) > 0 && length(local.az.route_filter.name) > local.az.route_filter.min_length
-      valid_name_unique = length(regexall(local.az.route_filter.regex, local.az.route_filter.name_unique)) > 0
+      valid_name_unique = local.az.route_filter.name_unique != null ? length(regexall(local.az.route_filter.regex, local.az.route_filter.name_unique)) > 0 : null
     }
     route_server = {
       valid_name        = length(regexall(local.az.route_server.regex, local.az.route_server.name)) > 0 && length(local.az.route_server.name) > local.az.route_server.min_length
-      valid_name_unique = length(regexall(local.az.route_server.regex, local.az.route_server.name_unique)) > 0
+      valid_name_unique = local.az.route_server.name_unique != null ? length(regexall(local.az.route_server.regex, local.az.route_server.name_unique)) > 0 : null
     }
     route_table = {
       valid_name        = length(regexall(local.az.route_table.regex, local.az.route_table.name)) > 0 && length(local.az.route_table.name) > local.az.route_table.min_length
-      valid_name_unique = length(regexall(local.az.route_table.regex, local.az.route_table.name_unique)) > 0
+      valid_name_unique = local.az.route_table.name_unique != null ? length(regexall(local.az.route_table.regex, local.az.route_table.name_unique)) > 0 : null
     }
     search_service = {
       valid_name        = length(regexall(local.az.search_service.regex, local.az.search_service.name)) > 0 && length(local.az.search_service.name) > local.az.search_service.min_length
-      valid_name_unique = length(regexall(local.az.search_service.regex, local.az.search_service.name_unique)) > 0
+      valid_name_unique = local.az.search_service.name_unique != null ? length(regexall(local.az.search_service.regex, local.az.search_service.name_unique)) > 0 : null
     }
     service_fabric_cluster = {
       valid_name        = length(regexall(local.az.service_fabric_cluster.regex, local.az.service_fabric_cluster.name)) > 0 && length(local.az.service_fabric_cluster.name) > local.az.service_fabric_cluster.min_length
-      valid_name_unique = length(regexall(local.az.service_fabric_cluster.regex, local.az.service_fabric_cluster.name_unique)) > 0
+      valid_name_unique = local.az.service_fabric_cluster.name_unique != null ? length(regexall(local.az.service_fabric_cluster.regex, local.az.service_fabric_cluster.name_unique)) > 0 : null
     }
     servicebus_namespace = {
       valid_name        = length(regexall(local.az.servicebus_namespace.regex, local.az.servicebus_namespace.name)) > 0 && length(local.az.servicebus_namespace.name) > local.az.servicebus_namespace.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_namespace.regex, local.az.servicebus_namespace.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_namespace.name_unique != null ? length(regexall(local.az.servicebus_namespace.regex, local.az.servicebus_namespace.name_unique)) > 0 : null
     }
     servicebus_namespace_authorization_rule = {
       valid_name        = length(regexall(local.az.servicebus_namespace_authorization_rule.regex, local.az.servicebus_namespace_authorization_rule.name)) > 0 && length(local.az.servicebus_namespace_authorization_rule.name) > local.az.servicebus_namespace_authorization_rule.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_namespace_authorization_rule.regex, local.az.servicebus_namespace_authorization_rule.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_namespace_authorization_rule.name_unique != null ? length(regexall(local.az.servicebus_namespace_authorization_rule.regex, local.az.servicebus_namespace_authorization_rule.name_unique)) > 0 : null
     }
     servicebus_queue = {
       valid_name        = length(regexall(local.az.servicebus_queue.regex, local.az.servicebus_queue.name)) > 0 && length(local.az.servicebus_queue.name) > local.az.servicebus_queue.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_queue.regex, local.az.servicebus_queue.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_queue.name_unique != null ? length(regexall(local.az.servicebus_queue.regex, local.az.servicebus_queue.name_unique)) > 0 : null
     }
     servicebus_queue_authorization_rule = {
       valid_name        = length(regexall(local.az.servicebus_queue_authorization_rule.regex, local.az.servicebus_queue_authorization_rule.name)) > 0 && length(local.az.servicebus_queue_authorization_rule.name) > local.az.servicebus_queue_authorization_rule.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_queue_authorization_rule.regex, local.az.servicebus_queue_authorization_rule.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_queue_authorization_rule.name_unique != null ? length(regexall(local.az.servicebus_queue_authorization_rule.regex, local.az.servicebus_queue_authorization_rule.name_unique)) > 0 : null
     }
     servicebus_subscription = {
       valid_name        = length(regexall(local.az.servicebus_subscription.regex, local.az.servicebus_subscription.name)) > 0 && length(local.az.servicebus_subscription.name) > local.az.servicebus_subscription.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_subscription.regex, local.az.servicebus_subscription.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_subscription.name_unique != null ? length(regexall(local.az.servicebus_subscription.regex, local.az.servicebus_subscription.name_unique)) > 0 : null
     }
     servicebus_subscription_rule = {
       valid_name        = length(regexall(local.az.servicebus_subscription_rule.regex, local.az.servicebus_subscription_rule.name)) > 0 && length(local.az.servicebus_subscription_rule.name) > local.az.servicebus_subscription_rule.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_subscription_rule.regex, local.az.servicebus_subscription_rule.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_subscription_rule.name_unique != null ? length(regexall(local.az.servicebus_subscription_rule.regex, local.az.servicebus_subscription_rule.name_unique)) > 0 : null
     }
     servicebus_topic = {
       valid_name        = length(regexall(local.az.servicebus_topic.regex, local.az.servicebus_topic.name)) > 0 && length(local.az.servicebus_topic.name) > local.az.servicebus_topic.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_topic.regex, local.az.servicebus_topic.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_topic.name_unique != null ? length(regexall(local.az.servicebus_topic.regex, local.az.servicebus_topic.name_unique)) > 0 : null
     }
     servicebus_topic_authorization_rule = {
       valid_name        = length(regexall(local.az.servicebus_topic_authorization_rule.regex, local.az.servicebus_topic_authorization_rule.name)) > 0 && length(local.az.servicebus_topic_authorization_rule.name) > local.az.servicebus_topic_authorization_rule.min_length
-      valid_name_unique = length(regexall(local.az.servicebus_topic_authorization_rule.regex, local.az.servicebus_topic_authorization_rule.name_unique)) > 0
+      valid_name_unique = local.az.servicebus_topic_authorization_rule.name_unique != null ? length(regexall(local.az.servicebus_topic_authorization_rule.regex, local.az.servicebus_topic_authorization_rule.name_unique)) > 0 : null
     }
     shared_image = {
       valid_name        = length(regexall(local.az.shared_image.regex, local.az.shared_image.name)) > 0 && length(local.az.shared_image.name) > local.az.shared_image.min_length
-      valid_name_unique = length(regexall(local.az.shared_image.regex, local.az.shared_image.name_unique)) > 0
+      valid_name_unique = local.az.shared_image.name_unique != null ? length(regexall(local.az.shared_image.regex, local.az.shared_image.name_unique)) > 0 : null
     }
     shared_image_gallery = {
       valid_name        = length(regexall(local.az.shared_image_gallery.regex, local.az.shared_image_gallery.name)) > 0 && length(local.az.shared_image_gallery.name) > local.az.shared_image_gallery.min_length
-      valid_name_unique = length(regexall(local.az.shared_image_gallery.regex, local.az.shared_image_gallery.name_unique)) > 0
+      valid_name_unique = local.az.shared_image_gallery.name_unique != null ? length(regexall(local.az.shared_image_gallery.regex, local.az.shared_image_gallery.name_unique)) > 0 : null
     }
     signalr_service = {
       valid_name        = length(regexall(local.az.signalr_service.regex, local.az.signalr_service.name)) > 0 && length(local.az.signalr_service.name) > local.az.signalr_service.min_length
-      valid_name_unique = length(regexall(local.az.signalr_service.regex, local.az.signalr_service.name_unique)) > 0
+      valid_name_unique = local.az.signalr_service.name_unique != null ? length(regexall(local.az.signalr_service.regex, local.az.signalr_service.name_unique)) > 0 : null
     }
     snapshots = {
       valid_name        = length(regexall(local.az.snapshots.regex, local.az.snapshots.name)) > 0 && length(local.az.snapshots.name) > local.az.snapshots.min_length
-      valid_name_unique = length(regexall(local.az.snapshots.regex, local.az.snapshots.name_unique)) > 0
+      valid_name_unique = local.az.snapshots.name_unique != null ? length(regexall(local.az.snapshots.regex, local.az.snapshots.name_unique)) > 0 : null
     }
     sql_elasticpool = {
       valid_name        = length(regexall(local.az.sql_elasticpool.regex, local.az.sql_elasticpool.name)) > 0 && length(local.az.sql_elasticpool.name) > local.az.sql_elasticpool.min_length
-      valid_name_unique = length(regexall(local.az.sql_elasticpool.regex, local.az.sql_elasticpool.name_unique)) > 0
+      valid_name_unique = local.az.sql_elasticpool.name_unique != null ? length(regexall(local.az.sql_elasticpool.regex, local.az.sql_elasticpool.name_unique)) > 0 : null
     }
     sql_failover_group = {
       valid_name        = length(regexall(local.az.sql_failover_group.regex, local.az.sql_failover_group.name)) > 0 && length(local.az.sql_failover_group.name) > local.az.sql_failover_group.min_length
-      valid_name_unique = length(regexall(local.az.sql_failover_group.regex, local.az.sql_failover_group.name_unique)) > 0
+      valid_name_unique = local.az.sql_failover_group.name_unique != null ? length(regexall(local.az.sql_failover_group.regex, local.az.sql_failover_group.name_unique)) > 0 : null
     }
     sql_firewall_rule = {
       valid_name        = length(regexall(local.az.sql_firewall_rule.regex, local.az.sql_firewall_rule.name)) > 0 && length(local.az.sql_firewall_rule.name) > local.az.sql_firewall_rule.min_length
-      valid_name_unique = length(regexall(local.az.sql_firewall_rule.regex, local.az.sql_firewall_rule.name_unique)) > 0
+      valid_name_unique = local.az.sql_firewall_rule.name_unique != null ? length(regexall(local.az.sql_firewall_rule.regex, local.az.sql_firewall_rule.name_unique)) > 0 : null
     }
     sql_server = {
       valid_name        = length(regexall(local.az.sql_server.regex, local.az.sql_server.name)) > 0 && length(local.az.sql_server.name) > local.az.sql_server.min_length
-      valid_name_unique = length(regexall(local.az.sql_server.regex, local.az.sql_server.name_unique)) > 0
+      valid_name_unique = local.az.sql_server.name_unique != null ? length(regexall(local.az.sql_server.regex, local.az.sql_server.name_unique)) > 0 : null
     }
     ssh_public_key = {
       valid_name        = length(regexall(local.az.ssh_public_key.regex, local.az.ssh_public_key.name)) > 0 && length(local.az.ssh_public_key.name) > local.az.ssh_public_key.min_length
-      valid_name_unique = length(regexall(local.az.ssh_public_key.regex, local.az.ssh_public_key.name_unique)) > 0
+      valid_name_unique = local.az.ssh_public_key.name_unique != null ? length(regexall(local.az.ssh_public_key.regex, local.az.ssh_public_key.name_unique)) > 0 : null
     }
     static_web_app = {
       valid_name        = length(regexall(local.az.static_web_app.regex, local.az.static_web_app.name)) > 0 && length(local.az.static_web_app.name) > local.az.static_web_app.min_length
-      valid_name_unique = length(regexall(local.az.static_web_app.regex, local.az.static_web_app.name_unique)) > 0
+      valid_name_unique = local.az.static_web_app.name_unique != null ? length(regexall(local.az.static_web_app.regex, local.az.static_web_app.name_unique)) > 0 : null
     }
     storage_account = {
       valid_name        = length(regexall(local.az.storage_account.regex, local.az.storage_account.name)) > 0 && length(local.az.storage_account.name) > local.az.storage_account.min_length
-      valid_name_unique = length(regexall(local.az.storage_account.regex, local.az.storage_account.name_unique)) > 0
+      valid_name_unique = local.az.storage_account.name_unique != null ? length(regexall(local.az.storage_account.regex, local.az.storage_account.name_unique)) > 0 : null
     }
     storage_blob = {
       valid_name        = length(regexall(local.az.storage_blob.regex, local.az.storage_blob.name)) > 0 && length(local.az.storage_blob.name) > local.az.storage_blob.min_length
-      valid_name_unique = length(regexall(local.az.storage_blob.regex, local.az.storage_blob.name_unique)) > 0
+      valid_name_unique = local.az.storage_blob.name_unique != null ? length(regexall(local.az.storage_blob.regex, local.az.storage_blob.name_unique)) > 0 : null
     }
     storage_container = {
       valid_name        = length(regexall(local.az.storage_container.regex, local.az.storage_container.name)) > 0 && length(local.az.storage_container.name) > local.az.storage_container.min_length
-      valid_name_unique = length(regexall(local.az.storage_container.regex, local.az.storage_container.name_unique)) > 0
+      valid_name_unique = local.az.storage_container.name_unique != null ? length(regexall(local.az.storage_container.regex, local.az.storage_container.name_unique)) > 0 : null
     }
     storage_data_lake_gen2_filesystem = {
       valid_name        = length(regexall(local.az.storage_data_lake_gen2_filesystem.regex, local.az.storage_data_lake_gen2_filesystem.name)) > 0 && length(local.az.storage_data_lake_gen2_filesystem.name) > local.az.storage_data_lake_gen2_filesystem.min_length
-      valid_name_unique = length(regexall(local.az.storage_data_lake_gen2_filesystem.regex, local.az.storage_data_lake_gen2_filesystem.name_unique)) > 0
+      valid_name_unique = local.az.storage_data_lake_gen2_filesystem.name_unique != null ? length(regexall(local.az.storage_data_lake_gen2_filesystem.regex, local.az.storage_data_lake_gen2_filesystem.name_unique)) > 0 : null
     }
     storage_queue = {
       valid_name        = length(regexall(local.az.storage_queue.regex, local.az.storage_queue.name)) > 0 && length(local.az.storage_queue.name) > local.az.storage_queue.min_length
-      valid_name_unique = length(regexall(local.az.storage_queue.regex, local.az.storage_queue.name_unique)) > 0
+      valid_name_unique = local.az.storage_queue.name_unique != null ? length(regexall(local.az.storage_queue.regex, local.az.storage_queue.name_unique)) > 0 : null
     }
     storage_share = {
       valid_name        = length(regexall(local.az.storage_share.regex, local.az.storage_share.name)) > 0 && length(local.az.storage_share.name) > local.az.storage_share.min_length
-      valid_name_unique = length(regexall(local.az.storage_share.regex, local.az.storage_share.name_unique)) > 0
+      valid_name_unique = local.az.storage_share.name_unique != null ? length(regexall(local.az.storage_share.regex, local.az.storage_share.name_unique)) > 0 : null
     }
     storage_share_directory = {
       valid_name        = length(regexall(local.az.storage_share_directory.regex, local.az.storage_share_directory.name)) > 0 && length(local.az.storage_share_directory.name) > local.az.storage_share_directory.min_length
-      valid_name_unique = length(regexall(local.az.storage_share_directory.regex, local.az.storage_share_directory.name_unique)) > 0
+      valid_name_unique = local.az.storage_share_directory.name_unique != null ? length(regexall(local.az.storage_share_directory.regex, local.az.storage_share_directory.name_unique)) > 0 : null
     }
     storage_table = {
       valid_name        = length(regexall(local.az.storage_table.regex, local.az.storage_table.name)) > 0 && length(local.az.storage_table.name) > local.az.storage_table.min_length
-      valid_name_unique = length(regexall(local.az.storage_table.regex, local.az.storage_table.name_unique)) > 0
+      valid_name_unique = local.az.storage_table.name_unique != null ? length(regexall(local.az.storage_table.regex, local.az.storage_table.name_unique)) > 0 : null
     }
     stream_analytics_function_javascript_udf = {
       valid_name        = length(regexall(local.az.stream_analytics_function_javascript_udf.regex, local.az.stream_analytics_function_javascript_udf.name)) > 0 && length(local.az.stream_analytics_function_javascript_udf.name) > local.az.stream_analytics_function_javascript_udf.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_function_javascript_udf.regex, local.az.stream_analytics_function_javascript_udf.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_function_javascript_udf.name_unique != null ? length(regexall(local.az.stream_analytics_function_javascript_udf.regex, local.az.stream_analytics_function_javascript_udf.name_unique)) > 0 : null
     }
     stream_analytics_job = {
       valid_name        = length(regexall(local.az.stream_analytics_job.regex, local.az.stream_analytics_job.name)) > 0 && length(local.az.stream_analytics_job.name) > local.az.stream_analytics_job.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_job.regex, local.az.stream_analytics_job.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_job.name_unique != null ? length(regexall(local.az.stream_analytics_job.regex, local.az.stream_analytics_job.name_unique)) > 0 : null
     }
     stream_analytics_output_blob = {
       valid_name        = length(regexall(local.az.stream_analytics_output_blob.regex, local.az.stream_analytics_output_blob.name)) > 0 && length(local.az.stream_analytics_output_blob.name) > local.az.stream_analytics_output_blob.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_output_blob.regex, local.az.stream_analytics_output_blob.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_output_blob.name_unique != null ? length(regexall(local.az.stream_analytics_output_blob.regex, local.az.stream_analytics_output_blob.name_unique)) > 0 : null
     }
     stream_analytics_output_eventhub = {
       valid_name        = length(regexall(local.az.stream_analytics_output_eventhub.regex, local.az.stream_analytics_output_eventhub.name)) > 0 && length(local.az.stream_analytics_output_eventhub.name) > local.az.stream_analytics_output_eventhub.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_output_eventhub.regex, local.az.stream_analytics_output_eventhub.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_output_eventhub.name_unique != null ? length(regexall(local.az.stream_analytics_output_eventhub.regex, local.az.stream_analytics_output_eventhub.name_unique)) > 0 : null
     }
     stream_analytics_output_mssql = {
       valid_name        = length(regexall(local.az.stream_analytics_output_mssql.regex, local.az.stream_analytics_output_mssql.name)) > 0 && length(local.az.stream_analytics_output_mssql.name) > local.az.stream_analytics_output_mssql.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_output_mssql.regex, local.az.stream_analytics_output_mssql.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_output_mssql.name_unique != null ? length(regexall(local.az.stream_analytics_output_mssql.regex, local.az.stream_analytics_output_mssql.name_unique)) > 0 : null
     }
     stream_analytics_output_servicebus_queue = {
       valid_name        = length(regexall(local.az.stream_analytics_output_servicebus_queue.regex, local.az.stream_analytics_output_servicebus_queue.name)) > 0 && length(local.az.stream_analytics_output_servicebus_queue.name) > local.az.stream_analytics_output_servicebus_queue.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_output_servicebus_queue.regex, local.az.stream_analytics_output_servicebus_queue.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_output_servicebus_queue.name_unique != null ? length(regexall(local.az.stream_analytics_output_servicebus_queue.regex, local.az.stream_analytics_output_servicebus_queue.name_unique)) > 0 : null
     }
     stream_analytics_output_servicebus_topic = {
       valid_name        = length(regexall(local.az.stream_analytics_output_servicebus_topic.regex, local.az.stream_analytics_output_servicebus_topic.name)) > 0 && length(local.az.stream_analytics_output_servicebus_topic.name) > local.az.stream_analytics_output_servicebus_topic.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_output_servicebus_topic.regex, local.az.stream_analytics_output_servicebus_topic.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_output_servicebus_topic.name_unique != null ? length(regexall(local.az.stream_analytics_output_servicebus_topic.regex, local.az.stream_analytics_output_servicebus_topic.name_unique)) > 0 : null
     }
     stream_analytics_reference_input_blob = {
       valid_name        = length(regexall(local.az.stream_analytics_reference_input_blob.regex, local.az.stream_analytics_reference_input_blob.name)) > 0 && length(local.az.stream_analytics_reference_input_blob.name) > local.az.stream_analytics_reference_input_blob.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_reference_input_blob.regex, local.az.stream_analytics_reference_input_blob.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_reference_input_blob.name_unique != null ? length(regexall(local.az.stream_analytics_reference_input_blob.regex, local.az.stream_analytics_reference_input_blob.name_unique)) > 0 : null
     }
     stream_analytics_stream_input_blob = {
       valid_name        = length(regexall(local.az.stream_analytics_stream_input_blob.regex, local.az.stream_analytics_stream_input_blob.name)) > 0 && length(local.az.stream_analytics_stream_input_blob.name) > local.az.stream_analytics_stream_input_blob.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_stream_input_blob.regex, local.az.stream_analytics_stream_input_blob.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_stream_input_blob.name_unique != null ? length(regexall(local.az.stream_analytics_stream_input_blob.regex, local.az.stream_analytics_stream_input_blob.name_unique)) > 0 : null
     }
     stream_analytics_stream_input_eventhub = {
       valid_name        = length(regexall(local.az.stream_analytics_stream_input_eventhub.regex, local.az.stream_analytics_stream_input_eventhub.name)) > 0 && length(local.az.stream_analytics_stream_input_eventhub.name) > local.az.stream_analytics_stream_input_eventhub.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_stream_input_eventhub.regex, local.az.stream_analytics_stream_input_eventhub.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_stream_input_eventhub.name_unique != null ? length(regexall(local.az.stream_analytics_stream_input_eventhub.regex, local.az.stream_analytics_stream_input_eventhub.name_unique)) > 0 : null
     }
     stream_analytics_stream_input_iothub = {
       valid_name        = length(regexall(local.az.stream_analytics_stream_input_iothub.regex, local.az.stream_analytics_stream_input_iothub.name)) > 0 && length(local.az.stream_analytics_stream_input_iothub.name) > local.az.stream_analytics_stream_input_iothub.min_length
-      valid_name_unique = length(regexall(local.az.stream_analytics_stream_input_iothub.regex, local.az.stream_analytics_stream_input_iothub.name_unique)) > 0
+      valid_name_unique = local.az.stream_analytics_stream_input_iothub.name_unique != null ? length(regexall(local.az.stream_analytics_stream_input_iothub.regex, local.az.stream_analytics_stream_input_iothub.name_unique)) > 0 : null
     }
     subnet = {
       valid_name        = length(regexall(local.az.subnet.regex, local.az.subnet.name)) > 0 && length(local.az.subnet.name) > local.az.subnet.min_length
-      valid_name_unique = length(regexall(local.az.subnet.regex, local.az.subnet.name_unique)) > 0
+      valid_name_unique = local.az.subnet.name_unique != null ? length(regexall(local.az.subnet.regex, local.az.subnet.name_unique)) > 0 : null
     }
     subnet_service_endpoint_storage_policy = {
       valid_name        = length(regexall(local.az.subnet_service_endpoint_storage_policy.regex, local.az.subnet_service_endpoint_storage_policy.name)) > 0 && length(local.az.subnet_service_endpoint_storage_policy.name) > local.az.subnet_service_endpoint_storage_policy.min_length
-      valid_name_unique = length(regexall(local.az.subnet_service_endpoint_storage_policy.regex, local.az.subnet_service_endpoint_storage_policy.name_unique)) > 0
+      valid_name_unique = local.az.subnet_service_endpoint_storage_policy.name_unique != null ? length(regexall(local.az.subnet_service_endpoint_storage_policy.regex, local.az.subnet_service_endpoint_storage_policy.name_unique)) > 0 : null
     }
     synapse_private_link_hub = {
       valid_name        = length(regexall(local.az.synapse_private_link_hub.regex, local.az.synapse_private_link_hub.name)) > 0 && length(local.az.synapse_private_link_hub.name) > local.az.synapse_private_link_hub.min_length
-      valid_name_unique = length(regexall(local.az.synapse_private_link_hub.regex, local.az.synapse_private_link_hub.name_unique)) > 0
+      valid_name_unique = local.az.synapse_private_link_hub.name_unique != null ? length(regexall(local.az.synapse_private_link_hub.regex, local.az.synapse_private_link_hub.name_unique)) > 0 : null
     }
     synapse_spark_pool = {
       valid_name        = length(regexall(local.az.synapse_spark_pool.regex, local.az.synapse_spark_pool.name)) > 0 && length(local.az.synapse_spark_pool.name) > local.az.synapse_spark_pool.min_length
-      valid_name_unique = length(regexall(local.az.synapse_spark_pool.regex, local.az.synapse_spark_pool.name_unique)) > 0
+      valid_name_unique = local.az.synapse_spark_pool.name_unique != null ? length(regexall(local.az.synapse_spark_pool.regex, local.az.synapse_spark_pool.name_unique)) > 0 : null
     }
     synapse_sql_pool = {
       valid_name        = length(regexall(local.az.synapse_sql_pool.regex, local.az.synapse_sql_pool.name)) > 0 && length(local.az.synapse_sql_pool.name) > local.az.synapse_sql_pool.min_length
-      valid_name_unique = length(regexall(local.az.synapse_sql_pool.regex, local.az.synapse_sql_pool.name_unique)) > 0
+      valid_name_unique = local.az.synapse_sql_pool.name_unique != null ? length(regexall(local.az.synapse_sql_pool.regex, local.az.synapse_sql_pool.name_unique)) > 0 : null
     }
     synapse_workspace = {
       valid_name        = length(regexall(local.az.synapse_workspace.regex, local.az.synapse_workspace.name)) > 0 && length(local.az.synapse_workspace.name) > local.az.synapse_workspace.min_length
-      valid_name_unique = length(regexall(local.az.synapse_workspace.regex, local.az.synapse_workspace.name_unique)) > 0
+      valid_name_unique = local.az.synapse_workspace.name_unique != null ? length(regexall(local.az.synapse_workspace.regex, local.az.synapse_workspace.name_unique)) > 0 : null
     }
     template_deployment = {
       valid_name        = length(regexall(local.az.template_deployment.regex, local.az.template_deployment.name)) > 0 && length(local.az.template_deployment.name) > local.az.template_deployment.min_length
-      valid_name_unique = length(regexall(local.az.template_deployment.regex, local.az.template_deployment.name_unique)) > 0
+      valid_name_unique = local.az.template_deployment.name_unique != null ? length(regexall(local.az.template_deployment.regex, local.az.template_deployment.name_unique)) > 0 : null
     }
     traffic_manager_profile = {
       valid_name        = length(regexall(local.az.traffic_manager_profile.regex, local.az.traffic_manager_profile.name)) > 0 && length(local.az.traffic_manager_profile.name) > local.az.traffic_manager_profile.min_length
-      valid_name_unique = length(regexall(local.az.traffic_manager_profile.regex, local.az.traffic_manager_profile.name_unique)) > 0
+      valid_name_unique = local.az.traffic_manager_profile.name_unique != null ? length(regexall(local.az.traffic_manager_profile.regex, local.az.traffic_manager_profile.name_unique)) > 0 : null
     }
     user_assigned_identity = {
       valid_name        = length(regexall(local.az.user_assigned_identity.regex, local.az.user_assigned_identity.name)) > 0 && length(local.az.user_assigned_identity.name) > local.az.user_assigned_identity.min_length
-      valid_name_unique = length(regexall(local.az.user_assigned_identity.regex, local.az.user_assigned_identity.name_unique)) > 0
+      valid_name_unique = local.az.user_assigned_identity.name_unique != null ? length(regexall(local.az.user_assigned_identity.regex, local.az.user_assigned_identity.name_unique)) > 0 : null
     }
     virtual_desktop_application_group = {
       valid_name        = length(regexall(local.az.virtual_desktop_application_group.regex, local.az.virtual_desktop_application_group.name)) > 0 && length(local.az.virtual_desktop_application_group.name) > local.az.virtual_desktop_application_group.min_length
-      valid_name_unique = length(regexall(local.az.virtual_desktop_application_group.regex, local.az.virtual_desktop_application_group.name_unique)) > 0
+      valid_name_unique = local.az.virtual_desktop_application_group.name_unique != null ? length(regexall(local.az.virtual_desktop_application_group.regex, local.az.virtual_desktop_application_group.name_unique)) > 0 : null
     }
     virtual_desktop_host_pool = {
       valid_name        = length(regexall(local.az.virtual_desktop_host_pool.regex, local.az.virtual_desktop_host_pool.name)) > 0 && length(local.az.virtual_desktop_host_pool.name) > local.az.virtual_desktop_host_pool.min_length
-      valid_name_unique = length(regexall(local.az.virtual_desktop_host_pool.regex, local.az.virtual_desktop_host_pool.name_unique)) > 0
+      valid_name_unique = local.az.virtual_desktop_host_pool.name_unique != null ? length(regexall(local.az.virtual_desktop_host_pool.regex, local.az.virtual_desktop_host_pool.name_unique)) > 0 : null
     }
     virtual_desktop_scaling_plan = {
       valid_name        = length(regexall(local.az.virtual_desktop_scaling_plan.regex, local.az.virtual_desktop_scaling_plan.name)) > 0 && length(local.az.virtual_desktop_scaling_plan.name) > local.az.virtual_desktop_scaling_plan.min_length
-      valid_name_unique = length(regexall(local.az.virtual_desktop_scaling_plan.regex, local.az.virtual_desktop_scaling_plan.name_unique)) > 0
+      valid_name_unique = local.az.virtual_desktop_scaling_plan.name_unique != null ? length(regexall(local.az.virtual_desktop_scaling_plan.regex, local.az.virtual_desktop_scaling_plan.name_unique)) > 0 : null
     }
     virtual_desktop_workspace = {
       valid_name        = length(regexall(local.az.virtual_desktop_workspace.regex, local.az.virtual_desktop_workspace.name)) > 0 && length(local.az.virtual_desktop_workspace.name) > local.az.virtual_desktop_workspace.min_length
-      valid_name_unique = length(regexall(local.az.virtual_desktop_workspace.regex, local.az.virtual_desktop_workspace.name_unique)) > 0
+      valid_name_unique = local.az.virtual_desktop_workspace.name_unique != null ? length(regexall(local.az.virtual_desktop_workspace.regex, local.az.virtual_desktop_workspace.name_unique)) > 0 : null
     }
     virtual_hub = {
       valid_name        = length(regexall(local.az.virtual_hub.regex, local.az.virtual_hub.name)) > 0 && length(local.az.virtual_hub.name) > local.az.virtual_hub.min_length
-      valid_name_unique = length(regexall(local.az.virtual_hub.regex, local.az.virtual_hub.name_unique)) > 0
+      valid_name_unique = local.az.virtual_hub.name_unique != null ? length(regexall(local.az.virtual_hub.regex, local.az.virtual_hub.name_unique)) > 0 : null
     }
     virtual_machine = {
       valid_name        = length(regexall(local.az.virtual_machine.regex, local.az.virtual_machine.name)) > 0 && length(local.az.virtual_machine.name) > local.az.virtual_machine.min_length
-      valid_name_unique = length(regexall(local.az.virtual_machine.regex, local.az.virtual_machine.name_unique)) > 0
+      valid_name_unique = local.az.virtual_machine.name_unique != null ? length(regexall(local.az.virtual_machine.regex, local.az.virtual_machine.name_unique)) > 0 : null
     }
     virtual_machine_extension = {
       valid_name        = length(regexall(local.az.virtual_machine_extension.regex, local.az.virtual_machine_extension.name)) > 0 && length(local.az.virtual_machine_extension.name) > local.az.virtual_machine_extension.min_length
-      valid_name_unique = length(regexall(local.az.virtual_machine_extension.regex, local.az.virtual_machine_extension.name_unique)) > 0
+      valid_name_unique = local.az.virtual_machine_extension.name_unique != null ? length(regexall(local.az.virtual_machine_extension.regex, local.az.virtual_machine_extension.name_unique)) > 0 : null
     }
     virtual_machine_restore_point_collection = {
       valid_name        = length(regexall(local.az.virtual_machine_restore_point_collection.regex, local.az.virtual_machine_restore_point_collection.name)) > 0 && length(local.az.virtual_machine_restore_point_collection.name) > local.az.virtual_machine_restore_point_collection.min_length
-      valid_name_unique = length(regexall(local.az.virtual_machine_restore_point_collection.regex, local.az.virtual_machine_restore_point_collection.name_unique)) > 0
+      valid_name_unique = local.az.virtual_machine_restore_point_collection.name_unique != null ? length(regexall(local.az.virtual_machine_restore_point_collection.regex, local.az.virtual_machine_restore_point_collection.name_unique)) > 0 : null
     }
     virtual_machine_scale_set = {
       valid_name        = length(regexall(local.az.virtual_machine_scale_set.regex, local.az.virtual_machine_scale_set.name)) > 0 && length(local.az.virtual_machine_scale_set.name) > local.az.virtual_machine_scale_set.min_length
-      valid_name_unique = length(regexall(local.az.virtual_machine_scale_set.regex, local.az.virtual_machine_scale_set.name_unique)) > 0
+      valid_name_unique = local.az.virtual_machine_scale_set.name_unique != null ? length(regexall(local.az.virtual_machine_scale_set.regex, local.az.virtual_machine_scale_set.name_unique)) > 0 : null
     }
     virtual_machine_scale_set_extension = {
       valid_name        = length(regexall(local.az.virtual_machine_scale_set_extension.regex, local.az.virtual_machine_scale_set_extension.name)) > 0 && length(local.az.virtual_machine_scale_set_extension.name) > local.az.virtual_machine_scale_set_extension.min_length
-      valid_name_unique = length(regexall(local.az.virtual_machine_scale_set_extension.regex, local.az.virtual_machine_scale_set_extension.name_unique)) > 0
+      valid_name_unique = local.az.virtual_machine_scale_set_extension.name_unique != null ? length(regexall(local.az.virtual_machine_scale_set_extension.regex, local.az.virtual_machine_scale_set_extension.name_unique)) > 0 : null
     }
     virtual_network = {
       valid_name        = length(regexall(local.az.virtual_network.regex, local.az.virtual_network.name)) > 0 && length(local.az.virtual_network.name) > local.az.virtual_network.min_length
-      valid_name_unique = length(regexall(local.az.virtual_network.regex, local.az.virtual_network.name_unique)) > 0
+      valid_name_unique = local.az.virtual_network.name_unique != null ? length(regexall(local.az.virtual_network.regex, local.az.virtual_network.name_unique)) > 0 : null
     }
     virtual_network_gateway = {
       valid_name        = length(regexall(local.az.virtual_network_gateway.regex, local.az.virtual_network_gateway.name)) > 0 && length(local.az.virtual_network_gateway.name) > local.az.virtual_network_gateway.min_length
-      valid_name_unique = length(regexall(local.az.virtual_network_gateway.regex, local.az.virtual_network_gateway.name_unique)) > 0
+      valid_name_unique = local.az.virtual_network_gateway.name_unique != null ? length(regexall(local.az.virtual_network_gateway.regex, local.az.virtual_network_gateway.name_unique)) > 0 : null
     }
     virtual_network_gateway_connection = {
       valid_name        = length(regexall(local.az.virtual_network_gateway_connection.regex, local.az.virtual_network_gateway_connection.name)) > 0 && length(local.az.virtual_network_gateway_connection.name) > local.az.virtual_network_gateway_connection.min_length
-      valid_name_unique = length(regexall(local.az.virtual_network_gateway_connection.regex, local.az.virtual_network_gateway_connection.name_unique)) > 0
+      valid_name_unique = local.az.virtual_network_gateway_connection.name_unique != null ? length(regexall(local.az.virtual_network_gateway_connection.regex, local.az.virtual_network_gateway_connection.name_unique)) > 0 : null
     }
     virtual_network_peering = {
       valid_name        = length(regexall(local.az.virtual_network_peering.regex, local.az.virtual_network_peering.name)) > 0 && length(local.az.virtual_network_peering.name) > local.az.virtual_network_peering.min_length
-      valid_name_unique = length(regexall(local.az.virtual_network_peering.regex, local.az.virtual_network_peering.name_unique)) > 0
+      valid_name_unique = local.az.virtual_network_peering.name_unique != null ? length(regexall(local.az.virtual_network_peering.regex, local.az.virtual_network_peering.name_unique)) > 0 : null
     }
     virtual_wan = {
       valid_name        = length(regexall(local.az.virtual_wan.regex, local.az.virtual_wan.name)) > 0 && length(local.az.virtual_wan.name) > local.az.virtual_wan.min_length
-      valid_name_unique = length(regexall(local.az.virtual_wan.regex, local.az.virtual_wan.name_unique)) > 0
+      valid_name_unique = local.az.virtual_wan.name_unique != null ? length(regexall(local.az.virtual_wan.regex, local.az.virtual_wan.name_unique)) > 0 : null
     }
     vpn_gateway = {
       valid_name        = length(regexall(local.az.vpn_gateway.regex, local.az.vpn_gateway.name)) > 0 && length(local.az.vpn_gateway.name) > local.az.vpn_gateway.min_length
-      valid_name_unique = length(regexall(local.az.vpn_gateway.regex, local.az.vpn_gateway.name_unique)) > 0
+      valid_name_unique = local.az.vpn_gateway.name_unique != null ? length(regexall(local.az.vpn_gateway.regex, local.az.vpn_gateway.name_unique)) > 0 : null
     }
     vpn_gateway_connection = {
       valid_name        = length(regexall(local.az.vpn_gateway_connection.regex, local.az.vpn_gateway_connection.name)) > 0 && length(local.az.vpn_gateway_connection.name) > local.az.vpn_gateway_connection.min_length
-      valid_name_unique = length(regexall(local.az.vpn_gateway_connection.regex, local.az.vpn_gateway_connection.name_unique)) > 0
+      valid_name_unique = local.az.vpn_gateway_connection.name_unique != null ? length(regexall(local.az.vpn_gateway_connection.regex, local.az.vpn_gateway_connection.name_unique)) > 0 : null
     }
     vpn_site = {
       valid_name        = length(regexall(local.az.vpn_site.regex, local.az.vpn_site.name)) > 0 && length(local.az.vpn_site.name) > local.az.vpn_site.min_length
-      valid_name_unique = length(regexall(local.az.vpn_site.regex, local.az.vpn_site.name_unique)) > 0
+      valid_name_unique = local.az.vpn_site.name_unique != null ? length(regexall(local.az.vpn_site.regex, local.az.vpn_site.name_unique)) > 0 : null
     }
     web_application_firewall_policy = {
       valid_name        = length(regexall(local.az.web_application_firewall_policy.regex, local.az.web_application_firewall_policy.name)) > 0 && length(local.az.web_application_firewall_policy.name) > local.az.web_application_firewall_policy.min_length
-      valid_name_unique = length(regexall(local.az.web_application_firewall_policy.regex, local.az.web_application_firewall_policy.name_unique)) > 0
+      valid_name_unique = local.az.web_application_firewall_policy.name_unique != null ? length(regexall(local.az.web_application_firewall_policy.regex, local.az.web_application_firewall_policy.name_unique)) > 0 : null
     }
     web_application_firewall_policy_rule_group = {
       valid_name        = length(regexall(local.az.web_application_firewall_policy_rule_group.regex, local.az.web_application_firewall_policy_rule_group.name)) > 0 && length(local.az.web_application_firewall_policy_rule_group.name) > local.az.web_application_firewall_policy_rule_group.min_length
-      valid_name_unique = length(regexall(local.az.web_application_firewall_policy_rule_group.regex, local.az.web_application_firewall_policy_rule_group.name_unique)) > 0
+      valid_name_unique = local.az.web_application_firewall_policy_rule_group.name_unique != null ? length(regexall(local.az.web_application_firewall_policy_rule_group.regex, local.az.web_application_firewall_policy_rule_group.name_unique)) > 0 : null
     }
     windows_virtual_machine = {
       valid_name        = length(regexall(local.az.windows_virtual_machine.regex, local.az.windows_virtual_machine.name)) > 0 && length(local.az.windows_virtual_machine.name) > local.az.windows_virtual_machine.min_length
-      valid_name_unique = length(regexall(local.az.windows_virtual_machine.regex, local.az.windows_virtual_machine.name_unique)) > 0
+      valid_name_unique = local.az.windows_virtual_machine.name_unique != null ? length(regexall(local.az.windows_virtual_machine.regex, local.az.windows_virtual_machine.name_unique)) > 0 : null
     }
     windows_virtual_machine_scale_set = {
       valid_name        = length(regexall(local.az.windows_virtual_machine_scale_set.regex, local.az.windows_virtual_machine_scale_set.name)) > 0 && length(local.az.windows_virtual_machine_scale_set.name) > local.az.windows_virtual_machine_scale_set.min_length
-      valid_name_unique = length(regexall(local.az.windows_virtual_machine_scale_set.regex, local.az.windows_virtual_machine_scale_set.name_unique)) > 0
+      valid_name_unique = local.az.windows_virtual_machine_scale_set.name_unique != null ? length(regexall(local.az.windows_virtual_machine_scale_set.regex, local.az.windows_virtual_machine_scale_set.name_unique)) > 0 : null
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ moved {
 }
 
 resource "random_string" "main" {
-  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+  count = coalesce(var.unique-seed, "") == "" && !var.unique-disabled ? 1 : 0
 
   length  = 60
   special = false
@@ -27,7 +27,7 @@ moved {
 }
 
 resource "random_string" "first_letter" {
-  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+  count = coalesce(var.unique-seed, "") == "" && !var.unique-disabled ? 1 : 0
 
   length  = 1
   special = false
@@ -39,7 +39,7 @@ resource "random_string" "first_letter" {
 
 locals {
   // adding a first letter to guarantee that you always start with a letter
-  random_safe_generation = var.unique-seed == "" && !var.unique-disabled ? join("", [random_string.first_letter[0].result, random_string.main[0].result]) : ""
+  random_safe_generation = coalesce(var.unique-seed, "") == "" && !var.unique-disabled ? join("", [random_string.first_letter[0].result, random_string.main[0].result]) : ""
   random                 = var.unique-disabled ? "" : substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
   prefix                 = join("-", var.prefix)
   prefix_safe            = lower(join("", var.prefix))

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.1"
+
   required_providers {
     random = {
       source  = "hashicorp/random"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 
 output "unique-seed" {
-  value = coalesce(var.unique-seed, local.random_safe_generation)
+  value = var.unique-disabled ? null : coalesce(var.unique-seed, local.random_safe_generation)
 }
 
 output "validation" {

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -22,6 +22,8 @@
 
 {{- define "main" -}}
 terraform {
+  required_version = ">= 1.1"
+
   required_providers {
     random = {
       source  = "hashicorp/random"

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -36,7 +36,7 @@ moved {
 }
 
 resource "random_string" "main" {
-  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+  count = coalesce(var.unique-seed, "") == "" && !var.unique-disabled ? 1 : 0
 
   length  = 60
   special = false
@@ -50,7 +50,7 @@ moved {
 }
 
 resource "random_string" "first_letter" {
-  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+  count = coalesce(var.unique-seed, "") == "" && !var.unique-disabled ? 1 : 0
 
   length  = 1
   special = false
@@ -62,7 +62,7 @@ resource "random_string" "first_letter" {
 
 locals {
   // adding a first letter to guarantee that you always start with a letter
-  random_safe_generation = var.unique-seed == "" && !var.unique-disabled ? join("", [random_string.first_letter[0].result, random_string.main[0].result]) : ""
+  random_safe_generation = coalesce(var.unique-seed, "") == "" && !var.unique-disabled ? join("", [random_string.first_letter[0].result, random_string.main[0].result]) : ""
   random                 = var.unique-disabled ? "" : substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
   prefix                 = join("-", var.prefix)
   prefix_safe            = lower(join("", var.prefix))

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -1,7 +1,7 @@
 {{- define "resources" -}}
     {{- .Name }} = {
       name        = substr(join("{{if .Dashes}}-{{ end }}", compact([local.prefix{{if not .Dashes}}_safe{{ end }}, "{{ .Slug }}", local.suffix{{if not .Dashes}}_safe{{ end }}])), 0, {{ .Length.Max }})
-      name_unique = substr(join("{{if .Dashes}}-{{ end }}", compact([local.prefix{{if not .Dashes}}_safe{{ end }}, "{{ .Slug }}", local.suffix_unique{{if not .Dashes}}_safe{{ end }}])), 0, {{ .Length.Max }})
+      name_unique = var.unique-disabled ? null : substr(join("{{if .Dashes}}-{{ end }}", compact([local.prefix{{if not .Dashes}}_safe{{ end }}, "{{ .Slug }}", local.suffix_unique{{if not .Dashes}}_safe{{ end }}])), 0, {{ .Length.Max }})
       dashes      = {{ .Dashes }}
       slug        = "{{ .Slug }}"
       min_length  = {{ .Length.Min }}
@@ -14,7 +14,7 @@
 {{- define "validation" -}}
     {{- .Name }} = {
       valid_name        = length(regexall(local.az.{{- .Name }}.regex, local.az.{{- .Name }}.name)) > 0 && length(local.az.{{- .Name }}.name) > local.az.{{- .Name }}.min_length
-      valid_name_unique = length(regexall(local.az.{{- .Name }}.regex, local.az.{{- .Name }}.name_unique)) > 0
+      valid_name_unique = local.az.{{- .Name }}.name_unique != null ? length(regexall(local.az.{{- .Name }}.regex, local.az.{{- .Name }}.name_unique)) > 0 : null
     }
 {{- end -}}
 
@@ -30,14 +30,28 @@ terraform {
   }
 }
 
+moved {
+  from = random_string.main
+  to   = random_string.main[0]
+}
+
 resource "random_string" "main" {
+  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+
   length  = 60
   special = false
   upper   = false
   numeric = var.unique-include-numbers
 }
 
+moved {
+  from = random_string.first_letter
+  to   = random_string.first_letter[0]
+}
+
 resource "random_string" "first_letter" {
+  count = var.unique-seed == "" && !var.unique-disabled ? 1 : 0
+
   length  = 1
   special = false
   upper   = false
@@ -48,14 +62,14 @@ resource "random_string" "first_letter" {
 
 locals {
   // adding a first letter to guarantee that you always start with a letter
-  random_safe_generation = join("", [random_string.first_letter.result, random_string.main.result])
-  random                 = substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
+  random_safe_generation = var.unique-seed == "" && !var.unique-disabled ? join("", [random_string.first_letter[0].result, random_string.main[0].result]) : ""
+  random                 = var.unique-disabled ? "" : substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
   prefix                 = join("-", var.prefix)
   prefix_safe            = lower(join("", var.prefix))
   suffix                 = join("-", var.suffix)
-  suffix_unique          = join("-", concat(var.suffix, [local.random]))
+  suffix_unique          = var.unique-disabled ? null : join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
-  suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
+  suffix_unique_safe     = var.unique-disabled ? null : lower(join("", concat(var.suffix, [local.random])))
   // Names based in the recomendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {

--- a/templates/outputs.tmpl
+++ b/templates/outputs.tmpl
@@ -7,7 +7,7 @@ output "{{ .Name }}" {
 
 {{ define "outputs" }}
 output "unique-seed" {
-  value = coalesce(var.unique-seed, local.random_safe_generation)
+  value = var.unique-disabled ? null : coalesce(var.unique-seed, local.random_safe_generation)
 }
 
 output "validation" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "unique-include-numbers" {
 }
 
 variable "unique-disabled" {
-  description = "If you want to disable the generation of unique random names"
+  description = "If you want to disable the generation of unique random names. When set to true, all name_unique outputs and the unique-seed output will be null."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,9 @@ variable "unique-include-numbers" {
   type        = bool
   default     = true
 }
+
+variable "unique-disabled" {
+  description = "If you want to disable the generation of unique random names"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR adds a new `unique-disabled` input variable (default `false`) that, when set to `true`, prevents `random_string` resources from being created and sets all `name_unique` outputs to `null`. This is useful when users don't need unique names and want to keep the Terraform state clean.

As a side effect, `random_string` resources are now also skipped when `unique-seed` is provided, since the random values were already being ignored by `coalesce()` but still created in state.

The `moved` blocks are included to ensure a smooth state transition for existing users.
