### PR TITLE
feat: add resource-slug-overrides option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,31 @@ postgresql_server = {
     }
 ```
 
+### Slug Overrides
+
+You can override the slug for specific resources by using the `resource-slug-overrides` input map.
+Each key must match the resource output key (for example `analysis_services_server` or `api_management`).
+When provided, the override value is normalized to lowercase and then applied to `slug`, `name`, and `name_unique`.
+Override values that are empty or whitespace-only are rejected at plan time.
+Keys that do not match a known resource output key do not affect naming outputs; a `check` assertion will still surface a warning with the offending key names during plan/apply.
+
+```tf
+module "naming" {
+  source = "Azure/naming/azurerm"
+
+  resource-slug-overrides = {
+    analysis_services_server = "asx"
+    api_management           = "gateway"
+  }
+}
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.3.2 |
 
 ## Providers
@@ -116,6 +136,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | It is not recommended that you use prefix by azure you should be using a suffix for your resources. | `list(string)` | `[]` | no |
+| <a name="input_resource-slug-overrides"></a> [resource-slug-overrides](#input\_resource-slug-overrides) | Optional per-resource slug override map keyed by module output name. | `map(string)` | `{}` | no |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | It is recommended that you specify a suffix for consistency. please use only lowercase characters when possible | `list(string)` | `[]` | no |
 | <a name="input_unique-include-numbers"></a> [unique-include-numbers](#input\_unique-include-numbers) | If you want to include numbers in the unique generation | `bool` | `true` | no |
 | <a name="input_unique-length"></a> [unique-length](#input\_unique-length) | Max length of the uniqueness suffix to be added | `number` | `4` | no |
@@ -425,7 +446,7 @@ No modules.
 
 # Contributing Guidelines
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -50,3 +50,22 @@ output "everything" {
 output "validation_everything" {
   value = module.everything.validation
 }
+
+// Example 5
+
+module "slug_override" {
+  source = "../"
+  resource-slug-overrides = {
+    analysis_services_server = "asx"
+    api_management           = "apix"
+  }
+}
+
+output "slug_override" {
+  value = {
+    analysis_services_server = module.slug_override.analysis_services_server.name_unique
+    api_management           = module.slug_override.api_management.name_unique
+    app_configuration        = module.slug_override.app_configuration.name_unique
+    app_service              = module.slug_override.app_service.name_unique
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ terraform {
       version = ">= 3.3.2"
     }
   }
+  required_version = ">= 1.5.0"
 }
 
 resource "random_string" "main" {
@@ -33,9 +34,14 @@ locals {
   suffix_unique          = join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
   suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
+  slug_overrides_safe = {
+    for resource_name, slug in var.resource-slug-overrides :
+    resource_name => lower(trimspace(coalesce(slug, "")))
+    if trimspace(coalesce(slug, "")) != "" && contains(keys(local.az_default), resource_name)
+  }
   // Names based on the recommendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
-  az = {
+  az_default = {
     analysis_services_server = {
       name        = substr(join("", compact([local.prefix_safe, "as", local.suffix_safe])), 0, 63)
       name_unique = substr(join("", compact([local.prefix_safe, "as", local.suffix_unique_safe])), 0, 63)
@@ -3017,6 +3023,16 @@ locals {
       regex       = "^[^\\/\"\\[\\]:|<>+=;,?*@&_][^\\/\"\\[\\]:|<>+=;,?*@&]+[^\\/\"\\[\\]:|<>+=;,?*@&.-]$"
     }
   }
+  az = merge(
+    local.az_default,
+    {
+      for resource_name, slug in local.slug_overrides_safe : resource_name => merge(local.az_default[resource_name], {
+        slug        = slug
+        name        = local.az_default[resource_name].dashes ? substr(join("-", compact([local.prefix, slug, local.suffix])), 0, local.az_default[resource_name].max_length) : substr(join("", compact([local.prefix_safe, slug, local.suffix_safe])), 0, local.az_default[resource_name].max_length)
+        name_unique = local.az_default[resource_name].dashes ? substr(join("-", compact([local.prefix, slug, local.suffix_unique])), 0, local.az_default[resource_name].max_length) : substr(join("", compact([local.prefix_safe, slug, local.suffix_unique_safe])), 0, local.az_default[resource_name].max_length)
+      })
+    }
+  )
   validation = {
     analysis_services_server = {
       valid_name        = length(regexall(local.az.analysis_services_server.regex, local.az.analysis_services_server.name)) > 0 && length(local.az.analysis_services_server.name) > local.az.analysis_services_server.min_length
@@ -4210,5 +4226,12 @@ locals {
       valid_name        = length(regexall(local.az.windows_virtual_machine_scale_set.regex, local.az.windows_virtual_machine_scale_set.name)) > 0 && length(local.az.windows_virtual_machine_scale_set.name) > local.az.windows_virtual_machine_scale_set.min_length
       valid_name_unique = length(regexall(local.az.windows_virtual_machine_scale_set.regex, local.az.windows_virtual_machine_scale_set.name_unique)) > 0
     }
+  }
+}
+
+check "resource_slug_overrides_keys" {
+  assert {
+    condition     = length(setsubtract(keys(var.resource-slug-overrides), keys(local.az_default))) == 0
+    error_message = "resource-slug-overrides contains unknown resource key(s): ${join(", ", tolist(setsubtract(keys(var.resource-slug-overrides), keys(local.az_default))))}"
   }
 }

--- a/templates/main.tmpl
+++ b/templates/main.tmpl
@@ -28,6 +28,7 @@ terraform {
       version = ">= 3.3.2"
     }
   }
+  required_version = ">= 1.5.0"
 }
 
 resource "random_string" "main" {
@@ -56,17 +57,39 @@ locals {
   suffix_unique          = join("-", concat(var.suffix, [local.random]))
   suffix_safe            = lower(join("", var.suffix))
   suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
+  slug_overrides_safe = {
+    for resource_name, slug in var.resource-slug-overrides :
+    resource_name => lower(trimspace(coalesce(slug, "")))
+    if trimspace(coalesce(slug, "")) != "" && contains(keys(local.az_default), resource_name)
+  }
   // Names based on the recommendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
-  az = {
+  az_default = {
     {{- range . }}
     {{ template  "resources" .}}
     {{- end }}
   }
+  az = merge(
+    local.az_default,
+    {
+      for resource_name, slug in local.slug_overrides_safe : resource_name => merge(local.az_default[resource_name], {
+        slug        = slug
+        name        = local.az_default[resource_name].dashes ? substr(join("-", compact([local.prefix, slug, local.suffix])), 0, local.az_default[resource_name].max_length) : substr(join("", compact([local.prefix_safe, slug, local.suffix_safe])), 0, local.az_default[resource_name].max_length)
+        name_unique = local.az_default[resource_name].dashes ? substr(join("-", compact([local.prefix, slug, local.suffix_unique])), 0, local.az_default[resource_name].max_length) : substr(join("", compact([local.prefix_safe, slug, local.suffix_unique_safe])), 0, local.az_default[resource_name].max_length)
+      })
+    }
+  )
   validation = {
     {{- range . }}
     {{ template  "validation" .}}
     {{- end }}
+  }
+}
+
+check "resource_slug_overrides_keys" {
+  assert {
+    condition     = length(setsubtract(keys(var.resource-slug-overrides), keys(local.az_default))) == 0
+    error_message = "resource-slug-overrides contains unknown resource key(s): ${join(", ", tolist(setsubtract(keys(var.resource-slug-overrides), keys(local.az_default))))}"
   }
 }
 {{ end }}

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,15 @@ variable "unique-include-numbers" {
   type        = bool
   default     = true
 }
+
+variable "resource-slug-overrides" {
+  description = "Optional per-resource slug override map keyed by module output name."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+
+  validation {
+    condition     = alltrue([for slug in values(var.resource-slug-overrides) : slug != null && trimspace(slug) != ""])
+    error_message = "resource-slug-overrides values must be non-null and not empty or whitespace-only."
+  }
+}


### PR DESCRIPTION
This pull request adds the variable to override all defined resource types from its default abbreviation.

**Case**
1. Where resources were created and later on its abbreviation change, the resource would be recreated.
2. When enterprises have a different naming standard of resources, but want use default naming for others resources.

**Example**

```hcl
module "slug_override" {
  source = "../"
  resource-slug-overrides = {
    analysis_services_server = "asx"
    api_management           = "apix"
  }
}
```

Out changes in this case to:
```hcl
analysis_services_server = "asijea" -> "asxijea"
api_management           = "api-ijea" -> "apix-ijea"
```

**Related**
rel #208 - this prevents a recreation
