### PR TITLE
feat: use compact for prefix and suffix variables in locals

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,12 +27,12 @@ locals {
   // adding a first letter to guarantee that you always start with a letter
   random_safe_generation = join("", [random_string.first_letter.result, random_string.main.result])
   random                 = substr(coalesce(var.unique-seed, local.random_safe_generation), 0, var.unique-length)
-  prefix                 = join("-", var.prefix)
-  prefix_safe            = lower(join("", var.prefix))
-  suffix                 = join("-", var.suffix)
-  suffix_unique          = join("-", concat(var.suffix, [local.random]))
-  suffix_safe            = lower(join("", var.suffix))
-  suffix_unique_safe     = lower(join("", concat(var.suffix, [local.random])))
+  prefix                 = join("-", compact(var.prefix))
+  prefix_safe            = lower(join("", compact(var.prefix)))
+  suffix                 = join("-", compact(var.suffix))
+  suffix_unique          = join("-", concat(compact(var.suffix), [local.random]))
+  suffix_safe            = lower(join("", compact(var.suffix)))
+  suffix_unique_safe     = lower(join("", concat(compact(var.suffix), [local.random])))
   // Names based on the recommendations of
   // https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/naming-and-tagging
   az = {


### PR DESCRIPTION
This pull request makes a small but important improvement to how prefixes and suffixes are handled in the `main.tf` Terraform configuration. The main change ensures that any empty values in the `var.prefix` and `var.suffix` lists are removed before being joined, which helps prevent unwanted dashes or empty segments in generated names.

- Improved name generation:
  * Updated all uses of `var.prefix` and `var.suffix` in local variables to use the `compact()` function, which removes empty values before joining. This results in cleaner, more predictable resource names and avoids issues caused by empty list elements.